### PR TITLE
`.fromDriver()`関数をindexに追加した

### DIFF
--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -1,4 +1,4 @@
-# clay-resource@1.0.0
+# clay-resource@1.0.1
 
 Resource accessor for ClayDB
 

--- a/lib/.index.js.hbs
+++ b/lib/.index.js.hbs
@@ -7,12 +7,14 @@
 
 const create = require('./create')
 const ClayResource = require('./clay_resource')
+const fromDriver = require('./from_driver')
 
 let lib = create.bind(this)
 
 Object.assign(lib, ClayResource, {
   create,
-  ClayResource
+  ClayResource,
+  fromDriver
 })
 
 module.exports = lib

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,12 +7,14 @@
 
 const create = require('./create')
 const ClayResource = require('./clay_resource')
+const fromDriver = require('./from_driver')
 
 let lib = create.bind(this)
 
 Object.assign(lib, ClayResource, {
   create,
-  ClayResource
+  ClayResource,
+  fromDriver
 })
 
 module.exports = lib

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ape-tasking": "^4.0.9",
     "ape-tmpl": "^5.0.20",
     "ape-updating": "^4.1.0",
-    "clay-driver-memory": "^2.1.2",
+    "clay-driver-memory": "^2.1.3",
     "coz": "^6.0.20",
     "injectmock": "^2.0.0",
     "request": "^2.79.0",

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -1,0 +1,32 @@
+/**
+ * Test case for index.
+ * Runs with mocha.
+ */
+'use strict'
+
+const index = require('../lib/index.js')
+const { ok } = require('assert')
+const co = require('co')
+
+describe('create', function () {
+  this.timeout(3000)
+
+  before(() => co(function * () {
+
+  }))
+
+  after(() => co(function * () {
+
+  }))
+
+  it('index', () => co(function * () {
+    let created = index({})
+    ok(created)
+
+    ok(index.create)
+    ok(index.ClayResource)
+    ok(index.fromDriver)
+  }))
+})
+
+/* global describe, before, after, it */


### PR DESCRIPTION
依存側から下記のように呼べるように

```javascript
const { fromDriver } = require('clay-resource')
```