### PR TITLE
Prepare用のmixinを用意した

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ tryExample()
 API Guide
 -----
 
-+ [clay-resource@2.4.2](./doc/api/api.md)
++ [clay-resource@2.4.3](./doc/api/api.md)
   + [create(args)](./doc/api/api.md#clay-resource-function-create)
   + [fromDriver(driver, nameString, options)](./doc/api/api.md#clay-resource-function-from-driver)
   + [ClayResource](./doc/api/api.md#clay-resource-class)

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -1,4 +1,4 @@
-# clay-resource@2.4.2
+# clay-resource@2.4.3
 
 Resource accessor for ClayDB
 

--- a/lib/clay_resource.js
+++ b/lib/clay_resource.js
@@ -9,6 +9,7 @@
  * @augments RefMixed
  * @augments SubMixed
  * @augments ThrowMixed
+ * @augments PrepareMixed
  * @param {string} nameString - Name string
  * @param {Object.<string, function>} bounds - Method bounds
  * @param {Object} [options={}] - Optional settings
@@ -30,6 +31,7 @@ const {
   annotateMix,
   subMix,
   throwMix,
+  prepareMix,
   policyMix
 } = require('./mixins')
 const {
@@ -47,6 +49,7 @@ const entity = (attributes) => decorate(create(
 )
 
 const ClayResourceBase = [
+  prepareMix,
   outboundMix,
   inboundMix,
   refMix,
@@ -110,6 +113,7 @@ class ClayResource extends ClayResourceBase {
   one (id) {
     const s = this
     return co(function * () {
+      yield s.prepareIfNeeded()
       let one = yield s.bounds.one(id)
       return s.outboundEntity(one)
     })
@@ -139,6 +143,7 @@ class ClayResource extends ClayResourceBase {
   list (condition = {}) {
     const s = this
     return co(function * () {
+      yield s.prepareIfNeeded()
       let collection = yield s.bounds.list(condition)
       return s.outboundCollection(collection)
     })
@@ -162,6 +167,7 @@ class ClayResource extends ClayResourceBase {
   create (attributes = {}) {
     const s = this
     return co(function * () {
+      yield s.prepareIfNeeded()
       attributes = yield s.inboundAttributes(attributes)
       let values = entity().set(attributes).as(s._resourceNameString).toValues()
       let raw = yield s.bounds.create(values)
@@ -191,6 +197,7 @@ class ClayResource extends ClayResourceBase {
   update (id, attributes = {}) {
     const s = this
     return co(function * () {
+      yield s.prepareIfNeeded()
       attributes = yield s.inboundAttributes(attributes)
       let has = yield s.has(id)
       if (!has) {
@@ -218,6 +225,7 @@ class ClayResource extends ClayResourceBase {
   destroy (id) {
     const s = this
     return co(function * () {
+      yield s.prepareIfNeeded()
       let destroyed = yield s.bounds.destroy(id)
       s.emit(ENTITY_DESTROY, { id, destroyed })
       return destroyed
@@ -256,6 +264,7 @@ class ClayResource extends ClayResourceBase {
   oneBulk (ids) {
     const s = this
     return co(function * () {
+      yield s.prepareIfNeeded()
       let oneHash = yield s.bounds.oneBulk(ids)
       return s.outboundEntityHash(oneHash)
     })
@@ -280,6 +289,7 @@ class ClayResource extends ClayResourceBase {
   listBulk (conditionArray = []) {
     const s = this
     return co(function * () {
+      yield s.prepareIfNeeded()
       let collectionAlly
       yield s.bounds.listBulk(conditionArray)
       return s.outboundCollectionArray(collectionAlly)
@@ -304,6 +314,7 @@ class ClayResource extends ClayResourceBase {
   createBulk (attributesArray = []) {
     const s = this
     return co(function * () {
+      yield s.prepareIfNeeded()
       attributesArray = yield s.inboundAttributesArray(attributesArray)
       let valuesArray = attributesArray.map((attributes) => entity().set(attributes).as(s._resourceNameString).toValues())
       let raw = yield s.bounds.createBulk(valuesArray)
@@ -332,6 +343,7 @@ class ClayResource extends ClayResourceBase {
   updateBulk (attributesHash = {}) {
     const s = this
     return co(function * () {
+      yield s.prepareIfNeeded()
       attributesHash = yield s.inboundAttributesHash(attributesHash)
       let ids = Object.keys(attributesHash)
       for (let id of ids) {
@@ -364,6 +376,7 @@ class ClayResource extends ClayResourceBase {
   destroyBulk (ids = []) {
     const s = this
     return co(function * () {
+      yield s.prepareIfNeeded()
       let destroyed = yield s.bounds.destroyBulk(ids)
       s.emit(ENTITY_DESTROY_BULK, { ids, destroyed })
       return destroyed
@@ -393,6 +406,7 @@ class ClayResource extends ClayResourceBase {
   cursor (options = {}) {
     const s = this
     return co(function * () {
+      yield s.prepareIfNeeded()
       let cursor = yield s.bounds.cursor(options)
       return cursor
     })
@@ -416,6 +430,7 @@ class ClayResource extends ClayResourceBase {
     const s = this
     let { sort = [] } = options
     return co(function * () {
+      yield s.prepareIfNeeded()
       let { entities } = yield s.list({ filter, page: { size: 1, number: 1 }, sort })
       return s.outboundEntity(entities[ 0 ])
     })
@@ -439,6 +454,7 @@ class ClayResource extends ClayResourceBase {
     const s = this
     let { by = null } = options
     return co(function * () {
+      yield s.prepareIfNeeded()
       let cursor = yield s.cursor({
         // TODO Filter with seal
       })
@@ -468,6 +484,7 @@ class ClayResource extends ClayResourceBase {
   has (id) {
     const s = this
     return co(function * () {
+      yield s.prepareIfNeeded()
       let one = yield s.one(id)
       return !!one
     })
@@ -488,6 +505,7 @@ class ClayResource extends ClayResourceBase {
   exists (filter = {}) {
     const s = this
     return co(function * () {
+      yield s.prepareIfNeeded()
       let count = yield s.count(filter)
       return count > 0
     })
@@ -508,6 +526,7 @@ class ClayResource extends ClayResourceBase {
   count (filter = {}) {
     const s = this
     return co(function * () {
+      yield s.prepareIfNeeded()
       let { meta } = yield s.list({ page: { number: 1, size: 1 }, filter })
       return meta.total
     })
@@ -528,6 +547,7 @@ class ClayResource extends ClayResourceBase {
   of (attributes = {}) {
     const s = this
     return co(function * () {
+      yield s.prepareIfNeeded()
       let found = yield s.first(attributes)
       if (found) {
         return found

--- a/lib/mixins/index.js
+++ b/lib/mixins/index.js
@@ -13,6 +13,7 @@ module.exports = {
   get inboundMix () { return d(require('./inbound_mix')) },
   get outboundMix () { return d(require('./outbound_mix')) },
   get policyMix () { return d(require('./policy_mix')) },
+  get prepareMix () { return d(require('./prepare_mix')) },
   get refMix () { return d(require('./ref_mix')) },
   get subMix () { return d(require('./sub_mix')) },
   get throwMix () { return d(require('./throw_mix')) }

--- a/lib/mixins/prepare_mix.js
+++ b/lib/mixins/prepare_mix.js
@@ -1,0 +1,113 @@
+/**
+ * Mixin for prepare feature
+ * @function prepareMix
+ * @param {function} BaseClass - Class to mix
+ * @returns {function} Mixed class
+ */
+'use strict'
+
+const co = require('co')
+const { LogPrefixes } = require('clay-constants')
+const { RESOURCE_PREFIX } = LogPrefixes
+
+/** @lends prepareMix */
+function prepareMix (BaseClass) {
+  /** @class PrepareMixed */
+  class PrepareMixed extends BaseClass {
+    get $$prepareMixed () {
+      return true
+    }
+
+    constructor () {
+      super(...arguments)
+      const s = this
+      s._needsPrepare = false
+      s._prepareTasks = {}
+    }
+
+    /**
+     * Do prepare if needed
+     * @returns {Promise}
+     */
+    prepareIfNeeded () {
+      const s = this
+      return co(function * () {
+        if (!s._needsPrepare) {
+          return null
+        }
+        let result = s.prepare()
+        s._needsPrepare = false
+        return result
+      })
+    }
+
+    /**
+     * Do preparing
+     * @returns {Promise.<Object>}
+     */
+    prepare () {
+      const s = this
+      return co(function * () {
+        let results = {}
+        for (let name of Object.keys(s._prepareTasks)) {
+          let task = s._prepareTasks[ name ]
+          results[ name ] = yield Promise.resolve(task.call(s, s))
+        }
+        return results
+      })
+    }
+
+    /**
+     * Add prepare task
+     * @param {string} name - Name of task
+     * @param {function} task - Task function
+     * @returns {PrepareMixed} Retuns this
+     */
+    addPrepareTask (name, task) {
+      const s = this
+      if (s.hasPrepareTask(name)) {
+        throw new Error(`${RESOURCE_PREFIX} Prepare task already registered: ${name}`)
+      }
+      s._prepareTasks[ name ] = task
+      return s
+    }
+
+    /**
+     * Check if has task
+     * @param {string} name
+     * @returns {boolean} Has or not
+     */
+    hasPrepareTask (name) {
+      const s = this
+      return !!s._prepareTasks[ name ]
+    }
+
+    /**
+     * Remove a task
+     * @param {string} name - Name of task
+     * @returns {PrepareMixed}
+     */
+    removePrepareTask (name) {
+      const s = this
+      delete s._prepareTasks[ name ]
+      return s
+    }
+
+    /**
+     * Set needs prepare
+     * @param {boolean} [needsPrepare=true] - Needs preparing
+     * @returns {PrepareMixed} Returns self
+     */
+    setNeedsPrepare (needsPrepare = true) {
+      const s = this
+      s._needsPrepare = needsPrepare
+      return s
+    }
+
+  }
+
+  return PrepareMixed
+}
+
+module.exports = prepareMix
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-resource",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "description": "Resource accessor for ClayDB",
   "browser": "shim/browser",
   "main": "lib",

--- a/test/clay_resource_test.js
+++ b/test/clay_resource_test.js
@@ -44,6 +44,25 @@ describe('clay-resource', function () {
     resource01.refs(resource02)
     deepEqual(Object.keys(resource03.refs()), [ 'resource01', 'resource02' ])
   }))
+
+  it('Register prepare task', () => co(function * () {
+    let count = 0
+    const counter = () => {
+      count++
+      return count
+    }
+    let resource01 = new ClayResource('resource01')
+    resource01.addPrepareTask('counter', counter)
+    resource01.setNeedsPrepare()
+    equal(count, 0)
+    resource01.prepareIfNeeded()
+    resource01.prepareIfNeeded()
+    equal(count, 1)
+    resource01.setNeedsPrepare()
+    resource01.prepareIfNeeded()
+    resource01.prepareIfNeeded()
+    equal(count, 2)
+  }))
 })
 
 /* global describe, before, after, it */

--- a/test/prepare_mix_test.js
+++ b/test/prepare_mix_test.js
@@ -1,0 +1,32 @@
+/**
+ * Test case for prepareMix.
+ * Runs with mocha.
+ */
+'use strict'
+
+const prepareMix = require('../lib/mixins/prepare_mix.js')
+const { ok } = require('assert')
+const co = require('co')
+
+describe('prepare-mix', function () {
+  this.timeout(3000)
+
+  before(() => co(function * () {
+
+  }))
+
+  after(() => co(function * () {
+
+  }))
+
+  it('Prepare mix', () => co(function * () {
+    const PrepareMixed = prepareMix(class {})
+    let prepareMixed = new PrepareMixed()
+    prepareMixed.addPrepareTask('foo', () => ({ foo: 1 }))
+    ok(prepareMixed.hasPrepareTask('foo'))
+    prepareMixed.removePrepareTask('foo')
+    ok(!prepareMixed.hasPrepareTask('foo'))
+  }))
+})
+
+/* global describe, before, after, it */


### PR DESCRIPTION
ClayResourceのインスタンスの生成は同期的に行ないたい。だが永続化されたメタ情報との比較など、非同期経由でのprepare処理も存在する。

明示的に非同期なを呼ばせるのは嫌なので、create/updateなどのタイミングで、必要があればprepareするような作りにした


```javascript
const resource = clayResource({ /* ... */ })

//内部処理で必要があれば先にprepareTaskを登録しておく
resource.addPrepareTask('assertPolicy', () => { /* ... */ }  
resource.setNeedsPrepare() // 準備が必要だフラグを立てる

// 事あるごとに以下を呼ぶ
await resource.prepareIfNeeded() // 非同期的な準備処理があれば実行する

```