### PR TITLE
unique制約を実装した

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ tryEvents()
 API Guide
 -----
 
-+ [clay-resource@2.5.3](./doc/api/api.md)
++ [clay-resource@2.5.4](./doc/api/api.md)
   + [create(args)](./doc/api/api.md#clay-resource-function-create)
   + [fromDriver(driver, nameString, options)](./doc/api/api.md#clay-resource-function-from-driver)
   + [ClayResource](./doc/api/api.md#clay-resource-class)

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -1,4 +1,4 @@
-# clay-resource@2.5.3
+# clay-resource@2.5.4
 
 Resource accessor for ClayDB
 

--- a/lib/inbounds/policy_inbound.js
+++ b/lib/inbounds/policy_inbound.js
@@ -1,6 +1,7 @@
 /**
  * Define inbound function for policy
  * @function policyInbound
+ * @param {ClayPolicy} policy - Policy to bind
  * @param {ClayResource} resource - Resource of entities
  * @returns {function} Inbound function
  */
@@ -8,15 +9,28 @@
 
 const co = require('co')
 const { LogPrefixes } = require('clay-constants')
+const { PolicyError } = require('clay-errors')
 
 /** @lends policyInbound */
 function policyInbound (policy) {
-  return function inbound (attributesArray) {
+  return function inbound (resource, attributesArray) {
     return co(function * () {
       for (let attributes of attributesArray) {
-        let policyError = policy && policy.validate(attributes)
+        if (!policy) {
+          continue
+        }
+        let policyError = policy.validate(attributes)
         if (policyError) {
           throw policyError
+        }
+        let uniqueFilters = policy.uniqueFilters(attributes)
+        for (let uniqueFilter of uniqueFilters) {
+          let exists = yield resource.exists(uniqueFilter)
+          if (exists) {
+            let error = new PolicyError('Unique constraint violation', { values: uniqueFilter })
+            delete error.stack
+            throw error
+          }
         }
       }
       return attributesArray

--- a/lib/inbounds/ref_inbound.js
+++ b/lib/inbounds/ref_inbound.js
@@ -1,7 +1,7 @@
 /**
  * Define inbound function for resource
  * @function refInbound
- * @param {ClayResource} resource - Resource of entities
+ * @param {ClayResource} refResource - Resource of entities
  * @returns {function} Inbound function
  */
 'use strict'
@@ -14,8 +14,8 @@ const clayResourceName = require('clay-resource-name')
 const { RESOURCE_PREFIX } = LogPrefixes
 
 /** @lends refInbound */
-function refInbound (resource) {
-  const resourceName = String(clayResourceName(resource))
+function refInbound (refResource) {
+  const refResourceName = String(clayResourceName(refResource))
   const parseAttribute = (name, attribute) => co(function * () {
     if (Array.isArray(attribute)) {
       return yield attribute.map((attribute) => parseAttribute(name, attribute))
@@ -25,9 +25,9 @@ function refInbound (resource) {
         console.warn(`${RESOURCE_PREFIX} You cannot use "${attribute}" as ref of "${name}" since it is not annotated`)
         return attribute
       }
-      let hit = String(attribute.$$as) === resourceName
+      let hit = String(attribute.$$as) === refResourceName
       if (hit) {
-        attribute = { $ref: refTo(resource, attribute.id) }
+        attribute = { $ref: refTo(refResource, attribute.id) }
       }
     }
     let $ref = parseRef(attribute && attribute.$ref)
@@ -38,7 +38,7 @@ function refInbound (resource) {
     return attribute
   })
 
-  return function inbound (attributesArray) {
+  return function inbound (resource, attributesArray) {
     return co(function * () {
       for (let attributes of attributesArray) {
         for (let name of Object.keys(attributes)) {

--- a/lib/mixins/inbound_mix.js
+++ b/lib/mixins/inbound_mix.js
@@ -66,7 +66,7 @@ function inboundMix (BaseClass) {
       const s = this
       return co(function * () {
         for (let inbound of s._inbounds.values()) {
-          attributesArray = yield Promise.resolve(inbound(attributesArray))
+          attributesArray = yield Promise.resolve(inbound(s, attributesArray))
         }
         return attributesArray
       })
@@ -75,7 +75,7 @@ function inboundMix (BaseClass) {
     /**
      * Inbound attributes
      * @param {EntityAttributes} attributes - Attributes to inbound
-     * @returns {Promise.<EntityAttributes>} Inboundd attributes
+     * @returns {Promise.<EntityAttributes>} Inbounded attributes
      */
     inboundAttributes (attributes) {
       const s = this

--- a/lib/mixins/outbound_mix.js
+++ b/lib/mixins/outbound_mix.js
@@ -65,8 +65,8 @@ function outboundMix (BaseClass) {
     applyOutbound (entities) {
       const s = this
       return co(function * () {
-        for (let handler of s._outbounds.values()) {
-          entities = yield Promise.resolve(handler(entities))
+        for (let outbound of s._outbounds.values()) {
+          entities = yield Promise.resolve(outbound(s, entities))
         }
         return entities
       })

--- a/lib/mixins/policy_mix.js
+++ b/lib/mixins/policy_mix.js
@@ -67,7 +67,7 @@ function policyMix (BaseClass) {
         policy = new ClayPolicy(policy)
       }
       s._policy = policy
-      s.addInbound(POLICY_INBOUND, policyInbound(policy))
+      s.addInbound(POLICY_INBOUND, policyInbound(policy, s))
       s.emit(POLICY_SET, { policy })
     }
 

--- a/lib/outbounds/annotation_outbound.js
+++ b/lib/outbounds/annotation_outbound.js
@@ -12,7 +12,7 @@ function annotationOutbound () {
    * @param {ClayEntity[]} - Entities
    * @returns {Promise.<ClayEntity[]>}
    */
-  return function outbound (entities) {
+  return function outbound (resource, entities) {
     for (let entity of entities) {
       for (let name of Object.keys(entity)) {
         if (/^\$\$/.test(name)) {

--- a/lib/outbounds/ref_outbound.js
+++ b/lib/outbounds/ref_outbound.js
@@ -1,7 +1,7 @@
 /**
  * Define outbound to load entity refs
  * @function refOutbound
- * @param {ClayResource} resource - Resource of entities
+ * @param {ClayResource} refResource - Resource of entities
  * @returns {function} Outbound function
  */
 'use strict'
@@ -14,8 +14,8 @@ const clayResourceName = require('clay-resource-name')
 const { RESOURCE_PREFIX } = LogPrefixes
 
 /** @lends refOutbound */
-function refOutbound (resource) {
-  const resourceName = String(clayResourceName(resource))
+function refOutbound (refResource) {
+  const refResourceName = String(clayResourceName(refResource))
   const outboundAttribute = (name, attribute) => co(function * () {
     if (Array.isArray(attribute)) {
       return yield attribute.map((attribute) => outboundAttribute(name, attribute))
@@ -25,19 +25,18 @@ function refOutbound (resource) {
         console.warn(`${RESOURCE_PREFIX} You cannot use "${attribute}" as ref of "${name}" since it is not annotated`)
         return attribute
       }
-      let hit = String(attribute.$$as) === resourceName
+      let hit = String(attribute.$$as) === refResourceName
       if (hit) {
-        attribute = { $ref: refTo(resource, attribute.id) }
+        attribute = { $ref: refTo(refResource, attribute.id) }
       }
     }
     let $ref = parseRef(attribute && attribute.$ref)
     if (!$ref) {
       return attribute
     }
-    let { resource: refResourceName, id: refId } = $ref
-    let hit = String(refResourceName) === resourceName
+    let hit = String($ref.resource) === refResourceName
     if (hit) {
-      return yield resource.one(refId)
+      return yield refResource.one($ref.id)
     }
   })
 
@@ -46,7 +45,7 @@ function refOutbound (resource) {
    * @param {ClayEntity[]} - Entities
    * @returns {Promise.<ClayEntity[]>}
    */
-  return function outbound (entities) {
+  return function outbound (resource, entities) {
     return co(function * () {
       for (let entity of entities) {
         for (let name of Object.keys(entity)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-resource",
-  "version": "2.5.4",
+  "version": "2.6.0",
   "description": "Resource accessor for ClayDB",
   "browser": "shim/browser",
   "main": "lib",
@@ -24,10 +24,10 @@
   "homepage": "https://github.com/realglobe-Inc/clay-resource#readme",
   "dependencies": {
     "clay-collection": "^1.0.2",
-    "clay-constants": "^2.8.1",
+    "clay-constants": "^2.8.2",
     "clay-entity": "^1.5.1",
     "clay-errors": "^2.0.1",
-    "clay-policy": "^1.3.1",
+    "clay-policy": "^1.5.2",
     "clay-resource-name": "^3.0.1",
     "clay-resource-ref": "^1.0.3",
     "clay-schemas": "^2.1.1",

--- a/test/from_driver_test.js
+++ b/test/from_driver_test.js
@@ -13,6 +13,7 @@ const clayPolicy = require('clay-policy')
 const { refTo } = require('clay-resource-ref')
 const { generate: generateKeys, verify } = require('clay-crypto')
 const co = require('co')
+const { DataTypes } = clayPolicy
 
 describe('from-driver', function () {
   this.timeout(3000)
@@ -204,7 +205,7 @@ describe('from-driver', function () {
   }))
 
   it('Policy check', () => co(function * () {
-    const { STRING, DATE } = clayPolicy.Types
+    const { STRING, DATE } = clayPolicy.DataTypes
     let driver = clayDriverMemory()
     let User = fromDriver(driver, 'User')
 
@@ -246,6 +247,27 @@ describe('from-driver', function () {
     equal(product01.code, '#1234')
     let product02 = yield Product.of({ code: '#1234' })
     equal(String(product01).id, String(product02).id)
+    yield Product.drop()
+  }))
+
+  it('Unique', () => co(function * () {
+    let driver = clayDriverMemory()
+    let Fruit = fromDriver(driver, 'Fruit')
+    Fruit.policy({
+      name: {
+        type: DataTypes.STRING,
+        unique: true
+      }
+    })
+    yield Fruit.create({ name: 'banana' })
+    let caught
+    try {
+      yield Fruit.create({ name: 'banana' })
+    } catch (thrown) {
+      caught = thrown
+    }
+    ok(caught)
+    yield Fruit.drop()
   }))
 })
 


### PR DESCRIPTION
Fieldに対してunique制約をかけられるようにした。複合キーについては別途検討

```javascript
it('Unique', () => co(function * () {
    let driver = clayDriverMemory()
    let Fruit = fromDriver(driver, 'Fruit')
    Fruit.policy({
      name: {
        type: DataTypes.STRING,
        unique: true
      }
    })
    yield Fruit.create({ name: 'banana' })
    let caught
    try {
      yield Fruit.create({ name: 'banana' })
    } catch (thrown) {
      caught = thrown
    }
    ok(caught)
    yield Fruit.drop()
  }))
```