### PR TITLE
相互参照しているときに無限ループする問題の解決

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ To define custom resource,  extends `ClayResource` class and use `.fromDriver()`
 API Guide
 -----
 
-+ [clay-resource@3.0.5](./doc/api/api.md)
++ [clay-resource@3.0.6](./doc/api/api.md)
   + [create(args)](./doc/api/api.md#clay-resource-function-create)
   + [fromDriver(driver, nameString, options)](./doc/api/api.md#clay-resource-function-from-driver)
   + [ClayResource](./doc/api/api.md#clay-resource-class)

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -1,4 +1,4 @@
-# clay-resource@3.0.5
+# clay-resource@3.0.6
 
 Resource accessor for ClayDB
 
@@ -7,7 +7,7 @@ Resource accessor for ClayDB
   + [fromDriver(driver, nameString, options)](#clay-resource-function-from-driver)
 + [`ClayResource`](#clay-resource-class) Class
   + [new ClayResource(nameString, bounds, options)](#clay-resource-class-clay-resource-constructor)
-  + [resource.one(id)](#clay-resource-class-clay-resource-one)
+  + [resource.one(id, options)](#clay-resource-class-clay-resource-one)
   + [resource.list(condition)](#clay-resource-class-clay-resource-list)
   + [resource.create(attributes)](#clay-resource-class-clay-resource-create)
   + [resource.update(id, attributes)](#clay-resource-class-clay-resource-update)
@@ -147,13 +147,14 @@ Constructor of ClayResource class
 
 <a class='md-heading-link' name="clay-resource-class-clay-resource-one" ></a>
 
-### resource.one(id) -> `Promise.<ClayEntity>`
+### resource.one(id, options) -> `Promise.<ClayEntity>`
 
 Get a resource
 
 | Param | Type | Description |
 | ----- | --- | -------- |
 | id | ClayId | Id of the entity |
+| options | Object | Optional settings |
 
 **Example**:
 

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -82,6 +82,14 @@
               "default": "",
               "optional": "",
               "nullable": ""
+            },
+            {
+              "name": "options",
+              "type": "Object",
+              "description": "Optional settings",
+              "default": "{}",
+              "optional": true,
+              "nullable": ""
             }
           ],
           "examples": [

--- a/lib/clay_resource.js
+++ b/lib/clay_resource.js
@@ -123,6 +123,7 @@ class ClayResource extends ClayResourceBase {
   /**
    * Get a resource
    * @param {ClayId} id - Id of the entity
+   * @param {Object} [options={}] - Optional settings
    * @returns {Promise.<ClayEntity>} Found entity
    * @example
    * const Product = lump.resource('Product')
@@ -131,20 +132,24 @@ class ClayResource extends ClayResourceBase {
    *   console.log(product)
    * }
    */
-  one (id) {
+  one (id, options = {}) {
     const s = this
+    let { skipResolvingRefFor = null } = options
     return co(function * () {
       yield s.prepareIfNeeded()
+      let actionContext = actionContextFor('one', {
+        skipResolvingRefFor
+      })
       assertId(id)
       let cached = s.gainCache(id)
       if (cached) {
-        return s.outboundEntity(cached)
+        return s.outboundEntity(cached, actionContext)
       }
       let one = yield s.bounds.one(id)
       if (one) {
         s.storeCache(one)
       }
-      return s.outboundEntity(one)
+      return s.outboundEntity(one, actionContext)
     })
   }
 
@@ -173,8 +178,9 @@ class ClayResource extends ClayResourceBase {
     const s = this
     return co(function * () {
       yield s.prepareIfNeeded()
+      let actionContext = actionContextFor('list', {})
       let collection = yield s.bounds.list(condition)
-      return s.outboundCollection(collection)
+      return s.outboundCollection(collection, actionContext)
     })
   }
 

--- a/lib/clay_resource.js
+++ b/lib/clay_resource.js
@@ -25,6 +25,7 @@
 const { EventEmitter } = require('events')
 const { decorate, create } = require('clay-entity')
 const co = require('co')
+const asleep = require('asleep')
 const ResourceEvents = require('./resource_events')
 const clayResourceName = require('clay-resource-name')
 const { DriverSpec } = require('clay-constants')
@@ -53,6 +54,12 @@ const {
   ENTITY_DESTROY_BULK,
   ENTITY_DROP
 } = ResourceEvents
+
+const {
+  CLAY_CACHE_CLEAR_DELAY = 10
+} = process.env
+
+const tick = () => asleep(CLAY_CACHE_CLEAR_DELAY + 1)
 
 const entity = (attributes) => decorate(create(
   Object.assign({}, attributes, { id: false }))
@@ -214,6 +221,7 @@ class ClayResource extends ClayResourceBase {
       let raw = yield s.bounds.create(values)
       let created = yield s.outboundEntity(raw, actionContext)
       s.emit(ENTITY_CREATE, { created })
+      yield tick()
       return created
     })
   }
@@ -250,6 +258,7 @@ class ClayResource extends ClayResourceBase {
       let raw = yield s.bounds.update(id, values)
       let updated = yield s.outboundEntity(raw, actionContext)
       s.emit(ENTITY_UPDATE, { id, updated })
+      yield tick()
       return updated
     })
   }
@@ -272,6 +281,7 @@ class ClayResource extends ClayResourceBase {
       assertId(id)
       let destroyed = yield s.bounds.destroy(id)
       s.emit(ENTITY_DESTROY, { id, destroyed })
+      yield tick()
       return destroyed
     })
   }
@@ -288,9 +298,12 @@ class ClayResource extends ClayResourceBase {
    */
   drop () {
     const s = this
-    let dropped = s.bounds.drop()
-    s.emit(ENTITY_DROP, { dropped })
-    return dropped
+    return co(function * () {
+      let dropped = yield s.bounds.drop()
+      s.emit(ENTITY_DROP, { dropped })
+      yield tick()
+      return dropped
+    })
   }
 
   /**
@@ -368,6 +381,7 @@ class ClayResource extends ClayResourceBase {
       let raw = yield s.bounds.createBulk(valuesArray)
       let created = yield s.outboundEntityArray(raw, actionContext)
       s.emit(ENTITY_CREATE_BULK, { created })
+      yield tick()
       return created
     })
   }
@@ -407,6 +421,7 @@ class ClayResource extends ClayResourceBase {
       let raw = yield s.bounds.updateBulk(valuesHash)
       let updated = yield s.outboundEntityHash(raw, actionContext)
       s.emit(ENTITY_UPDATE_BULK, { ids, updated })
+      yield tick()
       return updated
     })
   }
@@ -428,6 +443,7 @@ class ClayResource extends ClayResourceBase {
       yield s.prepareIfNeeded()
       let destroyed = yield s.bounds.destroyBulk(ids)
       s.emit(ENTITY_DESTROY_BULK, { ids, destroyed })
+      yield tick()
       return destroyed
     })
   }

--- a/lib/inbounds/ref_inbound.js
+++ b/lib/inbounds/ref_inbound.js
@@ -16,9 +16,9 @@ const { RESOURCE_PREFIX } = LogPrefixes
 /** @lends refInbound */
 function refInbound (refResource) {
   const refResourceName = String(clayResourceName(refResource))
-  const parseAttribute = (name, attribute) => co(function * () {
+  const inboundAttribute = (name, attribute) => co(function * () {
     if (Array.isArray(attribute)) {
-      return yield attribute.map((attribute) => parseAttribute(name, attribute))
+      return yield attribute.map((attribute) => inboundAttribute(name, attribute))
     }
     if (isEntity(attribute)) {
       if (!attribute.$$as) {
@@ -43,7 +43,7 @@ function refInbound (refResource) {
       for (let attributes of attributesArray) {
         for (let name of Object.keys(attributes)) {
           let attribute = attributes[ name ]
-          attributes[ name ] = yield parseAttribute(name, attribute)
+          attributes[ name ] = yield inboundAttribute(name, attribute)
         }
       }
       return attributesArray

--- a/lib/mixins/outbound_mix.js
+++ b/lib/mixins/outbound_mix.js
@@ -86,7 +86,7 @@ function outboundMix (BaseClass) {
           return entity
         }
         entity = clayEntity(entity)
-        let results = yield s.applyOutbound([ entity ])
+        let results = yield s.applyOutbound([ entity ], actionContext)
         return results[ 0 ]
       })
     }
@@ -103,7 +103,7 @@ function outboundMix (BaseClass) {
         if (!entityArray) {
           return entityArray
         }
-        return yield s.applyOutbound(entityArray.map(clayEntity))
+        return yield s.applyOutbound(entityArray.map(clayEntity), actionContext)
       })
     }
 

--- a/lib/outbounds/ref_outbound.js
+++ b/lib/outbounds/ref_outbound.js
@@ -16,9 +16,14 @@ const { RESOURCE_PREFIX } = LogPrefixes
 /** @lends refOutbound */
 function refOutbound (refResource) {
   const refResourceName = String(clayResourceName(refResource))
-  const outboundAttribute = (name, attribute) => co(function * () {
+  const outboundAttribute = (resourceName, name, attribute, actionContext) => co(function * () {
+    let skip = actionContext.skipResolvingRefFor === refResourceName
+    if (skip) {
+      return attribute
+    }
+
     if (Array.isArray(attribute)) {
-      return yield attribute.map((attribute) => outboundAttribute(name, attribute))
+      return yield attribute.map((attribute) => outboundAttribute(resourceName, name, attribute, actionContext))
     }
     if (isEntity(attribute)) {
       if (!attribute.$$as) {
@@ -36,7 +41,9 @@ function refOutbound (refResource) {
     }
     let hit = String($ref.resource) === refResourceName
     if (hit) {
-      return yield refResource.one($ref.id)
+      return yield refResource.one($ref.id, {
+        skipResolvingRefFor: resourceName
+      })
     }
 
     return attribute
@@ -45,14 +52,16 @@ function refOutbound (refResource) {
   /**
    * @function refOutbound
    * @param {ClayEntity[]} - Entities
+   * @param {Object} [actionContext={}]
    * @returns {Promise.<ClayEntity[]>}
    */
-  return function outbound (resource, entities) {
+  return function outbound (resource, entities, actionContext = {}) {
+    const resourceName = String(clayResourceName(resource))
     return co(function * () {
       for (let entity of entities) {
         for (let name of Object.keys(entity)) {
           let attribute = entity[ name ]
-          entity[ name ] = yield outboundAttribute(name, attribute)
+          entity[ name ] = yield outboundAttribute(resourceName, name, attribute, actionContext)
         }
       }
       return entities

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "clay-entity": "^2.0.1",
     "clay-errors": "^3.0.1",
     "clay-policy": "^2.0.2",
-    "clay-resource-cache": "^1.0.3",
+    "clay-resource-cache": "^1.0.4",
     "clay-resource-name": "^4.0.1",
     "clay-resource-ref": "^2.0.1",
     "clay-schemas": "^4.0.3",
+    "asleep": "^1.0.3",
     "co": "^4.6.0"
   },
   "devDependencies": {
@@ -44,9 +45,8 @@
     "ape-tasking": "^4.0.9",
     "ape-tmpl": "^5.0.20",
     "ape-updating": "^4.1.0",
-    "asleep": "^1.0.3",
     "clay-driver-memory": "^4.0.1",
-    "clay-driver-sqlite": "^3.0.1",
+    "clay-driver-sqlite": "^3.0.2",
     "claydb-assets": "^2.0.3",
     "coz": "^6.0.20",
     "filecopy": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "clay-entity": "^2.0.1",
     "clay-errors": "^3.0.1",
     "clay-policy": "^2.0.2",
-    "clay-resource-cache": "^1.0.2",
+    "clay-resource-cache": "^1.0.3",
     "clay-resource-name": "^4.0.1",
     "clay-resource-ref": "^2.0.1",
     "clay-schemas": "^4.0.3",

--- a/test/from_driver_test.js
+++ b/test/from_driver_test.js
@@ -332,6 +332,28 @@ describe('from-driver', function () {
     let orange01AgainAgain = yield Fruit.one(orange01.id)
     equal(orange01AgainAgain, null)
   }))
+
+  it('Circular refs', () => co(function * () {
+    let driver = clayDriverMemory()
+    let Toy = fromDriver(driver, 'Toy')
+    let House = fromDriver(driver, 'House')
+
+    Toy.refs(House)
+    House.refs(Toy)
+
+    let house01 = yield House.create({ name: 'house01' })
+
+    let toy01 = yield Toy.create({ name: 'toy01', house: house01 })
+    let toy02 = yield Toy.create({ name: 'toy02', house: house01 })
+
+    yield House.update(house01.id, { toys: [ toy01, toy02 ] })
+
+    let house01Again = yield House.one(house01.id)
+    equal(house01Again.toys[ 0 ].house.$ref, `House#${house01.id}`)
+
+    let toy01Again = yield Toy.one(toy01.id)
+    equal(toy01Again.house.toys[ 0 ].$ref, `Toy#${toy01.id}`)
+  }))
 })
 
 /* global describe, before, after, it */

--- a/test/from_driver_test.js
+++ b/test/from_driver_test.js
@@ -322,7 +322,6 @@ describe('from-driver', function () {
     equal(Fruit._resourceCache.size, 2)
 
     yield Fruit.update(orange01.id, { vr: 2 })
-    yield asleep(300)
     equal(Fruit._resourceCache.size, 1)
     let orange01Again = yield Fruit.one(orange01.id)
     equal(orange01Again.vr, 2)


### PR DESCRIPTION
HouseがToyを参照し、ToyがHouseを参照するようなとき。

oneで持ってくるときに無限ループに陥る問題を解決した。

toyのhouseのtoyは参照解決しない。

```javascript

it('Circular refs', () => co(function * () {
    let driver = clayDriverMemory()
    let Toy = fromDriver(driver, 'Toy')
    let House = fromDriver(driver, 'House')

    Toy.refs(House)
    House.refs(Toy)

    let house01 = yield House.create({ name: 'house01' })

    let toy01 = yield Toy.create({ name: 'toy01', house: house01 })
    let toy02 = yield Toy.create({ name: 'toy02', house: house01 })

    yield House.update(house01.id, { toys: [ toy01, toy02 ] })

    let house01Again = yield House.one(house01.id)
    equal(house01Again.toys[ 0 ].house.$ref, `House#${house01.id}`)

    let toy01Again = yield Toy.one(toy01.id)
    equal(toy01Again.house.toys[ 0 ].$ref, `Toy#${toy01.id}`)
  }))
```