### PR TITLE
strictオプションをつけたときに、oneで見つからなければエラーを投げる

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ To define custom resource,  extends `ClayResource` class and use `.fromDriver()`
 API Guide
 -----
 
-+ [clay-resource@3.0.8](./doc/api/api.md)
++ [clay-resource@3.0.9](./doc/api/api.md)
   + [create(args)](./doc/api/api.md#clay-resource-function-create)
   + [fromDriver(driver, nameString, options)](./doc/api/api.md#clay-resource-function-from-driver)
   + [ClayResource](./doc/api/api.md#clay-resource-class)

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -1,4 +1,4 @@
-# clay-resource@3.0.8
+# clay-resource@3.0.9
 
 Resource accessor for ClayDB
 
@@ -155,6 +155,7 @@ Get a resource
 | ----- | --- | -------- |
 | id | ClayId | Id of the entity |
 | options | Object | Optional settings |
+| options.strict | boolean | If true, throws an error when not found |
 
 **Example**:
 

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -90,6 +90,14 @@
               "default": "{}",
               "optional": true,
               "nullable": ""
+            },
+            {
+              "name": "options.strict",
+              "type": "boolean",
+              "description": "If true, throws an error when not found",
+              "default": "",
+              "optional": true,
+              "nullable": ""
             }
           ],
           "examples": [

--- a/lib/clay_resource.js
+++ b/lib/clay_resource.js
@@ -29,6 +29,7 @@ const ResourceEvents = require('./resource_events')
 const clayResourceName = require('clay-resource-name')
 const { DriverSpec } = require('clay-constants')
 const { RESOURCE_BINDABLE_METHODS } = DriverSpec
+const { NotFoundError } = require('clay-errors')
 const {
   cloneMix,
   inboundMix,
@@ -125,6 +126,7 @@ class ClayResource extends ClayResourceBase {
    * Get a resource
    * @param {ClayId} id - Id of the entity
    * @param {Object} [options={}] - Optional settings
+   * @param {boolean} [options.strict] - If true, throws an error when not found
    * @returns {Promise.<ClayEntity>} Found entity
    * @example
    * const Product = lump.resource('Product')
@@ -135,7 +137,10 @@ class ClayResource extends ClayResourceBase {
    */
   one (id, options = {}) {
     const s = this
-    let { skipResolvingRefFor = null } = options
+    let {
+      skipResolvingRefFor = null,
+      strict = false
+    } = options
     return co(function * () {
       yield s.prepareIfNeeded()
       let actionContext = actionContextFor('one', {
@@ -149,6 +154,10 @@ class ClayResource extends ClayResourceBase {
       let one = yield s.bounds.one(id)
       if (one) {
         s.storeCache(one)
+      } else {
+        if (strict) {
+          throw new NotFoundError(`Entity not found for: "${id}"`)
+        }
       }
       return s.outboundEntity(one, actionContext)
     })
@@ -544,7 +553,7 @@ class ClayResource extends ClayResourceBase {
     return co(function * () {
       yield s.prepareIfNeeded()
       id = sureId(id)
-      let one = yield s.one(id)
+      let one = yield s.one(id, { strict: false })
       return !!one
     })
   }

--- a/test/from_driver_test.js
+++ b/test/from_driver_test.js
@@ -421,6 +421,23 @@ describe('from-driver', function () {
     yield User.destroy(user01)
     ok(!(yield User.has(user01)))
   }))
+
+  it('Use strict options', () => co(function * () {
+    let driver = clayDriverMemory()
+    let User = fromDriver(driver, 'User')
+    let user01 = yield User.create({ name: 'Rider01' })
+    yield User.one(user01.id, { strict: false })
+    yield User.one(user01.id, { strict: true })
+
+    yield User.one('__invalid_id__', { strict: false })
+    let caught
+    try {
+      yield User.one('__invalid_id__', { strict: true })
+    } catch (e) {
+      caught = e
+    }
+    ok(caught)
+  }))
 })
 
 /* global describe, before, after, it */


### PR DESCRIPTION
```javascript
let user01 = await User.one('__invalid_id__') // Returns null
let user02 = await User.one('__invalid_id__', { strict: true}) // Throw error
```