### PR TITLE
listの結果に渡したconditionがdemandとして含まれるようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ To define custom resource,  extends `ClayResource` class and use `.fromDriver()`
 API Guide
 -----
 
-+ [clay-resource@3.1.0](./doc/api/api.md)
++ [clay-resource@3.1.1](./doc/api/api.md)
   + [create(args)](./doc/api/api.md#clay-resource-function-create)
   + [fromDriver(driver, nameString, options)](./doc/api/api.md#clay-resource-function-from-driver)
   + [ClayResource](./doc/api/api.md#clay-resource-class)

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -1,4 +1,4 @@
-# clay-resource@3.1.0
+# clay-resource@3.1.1
 
 Resource accessor for ClayDB
 

--- a/lib/clay_resource.js
+++ b/lib/clay_resource.js
@@ -190,10 +190,11 @@ class ClayResource extends ClayResourceBase {
     const s = this
     return co(function * () {
       yield s.prepareIfNeeded()
-      let actionContext = actionContextFor('list', {})
+      let actionContext = actionContextFor('list', { condition })
       let collection = yield s.bounds.list(
         s.parseCondition(condition)
       )
+      Object.assign(collection, { demand: condition })
       return s.outboundCollection(collection, actionContext)
     })
   }
@@ -350,11 +351,14 @@ class ClayResource extends ClayResourceBase {
     const s = this
     return co(function * () {
       yield s.prepareIfNeeded()
-      let actionContext = actionContextFor('listBulk', {})
-      let collectionAlly = yield s.bounds.listBulk(
+      let actionContext = actionContextFor('listBulk', { conditionArray })
+      let collectionArray = (yield s.bounds.listBulk(
         s.parseConditionArray(conditionArray)
-      )
-      return s.outboundCollectionArray(collectionAlly, actionContext)
+      ))
+      collectionArray.map((collection, i) => Object.assign(collection, {
+        demand: conditionArray[ i ]
+      }))
+      return s.outboundCollectionArray(collectionArray, actionContext)
     })
   }
 

--- a/lib/mixins/outbound_mix.js
+++ b/lib/mixins/outbound_mix.js
@@ -121,6 +121,7 @@ function outboundMix (BaseClass) {
         }
         collection = clayCollection(collection)
         collection.meta = Object.assign({}, collection.meta)
+        collection.demand = Object.assign({}, collection.demand)
         collection.entities = yield s.applyOutbound(collection.entities.map(clayEntity), actionContext)
         return collection
       })

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/realglobe-Inc/clay-resource#readme",
   "dependencies": {
     "asleep": "^1.0.3",
-    "clay-collection": "^2.0.1",
+    "clay-collection": "^3.0.1",
     "clay-constants": "^3.0.1",
     "clay-entity": "^2.0.1",
     "clay-errors": "^3.0.1",

--- a/test/from_driver_test.js
+++ b/test/from_driver_test.js
@@ -349,10 +349,19 @@ describe('from-driver', function () {
       yield User.create({ name: 'user01', org: org01 })
       yield User.create({ name: 'user02', org: org02 })
 
-      let { meta, entities } = yield User.list({ filter: { org: org01 } })
+      let { meta, entities, demand } = yield User.list({ filter: { org: org01 } })
       equal(meta.length, 1)
       let [ user ] = entities
       equal(user.name, 'user01')
+      equal(demand.filter.org.$ref, `Org#${org01.id}`)
+
+      {
+        let [ { meta, entities, demand } ] = yield User.listBulk([ { filter: { org: org01 } } ])
+        equal(meta.length, 1)
+        let [ user ] = entities
+        equal(user.name, 'user01')
+        equal(demand.filter.org.$ref, `Org#${org01.id}`)
+      }
     }
   }))
 


### PR DESCRIPTION
再検索やページングのため。

```javascript
let { meta, entities, demand } = yield User.list({ filter: { org: org01 } })
equal(meta.length, 1)
let [ user ] = entities
equal(user.name, 'user01')
equal(demand.filter.org.$ref, `Org#${org01.id}`)
```