### PR TITLE
ResourceにひもづくEntityを拡張できるようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ To define custom resource,  extends `ClayResource` class and use `.fromDriver()`
 API Guide
 -----
 
-+ [clay-resource@3.1.2](./doc/api/api.md)
++ [clay-resource@3.1.3](./doc/api/api.md)
   + [create(args)](./doc/api/api.md#clay-resource-function-create)
   + [fromDriver(driver, nameString, options)](./doc/api/api.md#clay-resource-function-from-driver)
   + [ClayResource](./doc/api/api.md#clay-resource-class)

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -1,4 +1,4 @@
-# clay-resource@3.1.2
+# clay-resource@3.1.3
 
 Resource accessor for ClayDB
 

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1689,7 +1689,7 @@
       },
       "functions": [
         {
-          "name": "toResourceCollection",
+          "name": "createResourceCollection",
           "access": "",
           "virtual": false,
           "description": "Convert collection into resource collection",
@@ -1829,7 +1829,7 @@
       },
       "functions": [
         {
-          "name": "toResourceEntity",
+          "name": "createResourceEntity",
           "access": "",
           "virtual": false,
           "description": "Convert entity into resource entity",
@@ -1847,6 +1847,27 @@
           "returns": {
             "type": "EntityMixed.ResourceEntity",
             "description": ""
+          }
+        },
+        {
+          "name": "enhanceResourceEntity",
+          "access": "",
+          "virtual": false,
+          "description": "Extend resource entity",
+          "parameters": [
+            {
+              "name": "enhancer",
+              "type": "function",
+              "description": "Enhancer function",
+              "default": "",
+              "optional": "",
+              "nullable": ""
+            }
+          ],
+          "examples": [],
+          "returns": {
+            "type": "EntityMixed",
+            "description": "Returns this for chaining"
           }
         }
       ]

--- a/lib/clay_resource.js
+++ b/lib/clay_resource.js
@@ -502,11 +502,15 @@ class ClayResource extends ClayResourceBase {
    */
   first (filter, options = {}) {
     const s = this
-    let { sort = [] } = options
+    let {
+      sort = [],
+      skip = 0
+    } = options
     let actionContext = actionContextFor('first', {})
     return co(function * () {
       yield s.prepareIfNeeded()
-      let { entities } = yield s.list({ filter, page: { size: 1, number: 1 }, sort })
+      let page = { size: 1, number: 1 + skip }
+      let { entities } = yield s.list({ filter, page, sort })
       return yield s.outboundEntity(entities[ 0 ], actionContext)
     })
   }

--- a/lib/mixins/collection_mix.js
+++ b/lib/mixins/collection_mix.js
@@ -27,10 +27,21 @@ function collectionMix (BaseClass) {
      * @param {Collection} collection - Collection to convert
      * @returns {CollectionMixed.ResourceCollection}
      */
-    toResourceCollection (collection) {
+    createResourceCollection (collection) {
       const s = this
       const { ResourceCollection } = s
       return new ResourceCollection(collection)
+    }
+
+    /**
+     * Extend resource collection
+     * @param {function} enhancer - Enhancer function
+     * @returns {EntityMixed} Returns this for chaining
+     */
+    enhanceResourceCollection (enhancer) {
+      const s = this
+      s.ResourceCollection = enhancer(s.ResourceCollection)
+      return s
     }
   }
 

--- a/lib/mixins/entity_mix.js
+++ b/lib/mixins/entity_mix.js
@@ -23,7 +23,7 @@ function entityMix (BaseClass) {
 
       s.ResourceEntity = define(s)
       s.addOutbound(ENTITY_OUTBOUND_NAME, (resource, entities, actionContext = {}) =>
-        entities.map((entity) => s.toResourceEntity(entity))
+        entities.map((entity) => s.createResourceEntity(entity))
       )
     }
 
@@ -32,10 +32,21 @@ function entityMix (BaseClass) {
      * @param {Entity} entity to convert
      * @returns {EntityMixed.ResourceEntity}
      */
-    toResourceEntity (entity) {
+    createResourceEntity (entity) {
       const s = this
       const { ResourceEntity } = s
       return new ResourceEntity(entity)
+    }
+
+    /**
+     * Extend resource entity
+     * @param {function} enhancer - Enhancer function
+     * @returns {EntityMixed} Returns this for chaining
+     */
+    enhanceResourceEntity (enhancer) {
+      const s = this
+      s.ResourceEntity = enhancer(s.ResourceEntity)
+      return s
     }
   }
 

--- a/lib/mixins/outbound_mix.js
+++ b/lib/mixins/outbound_mix.js
@@ -126,7 +126,7 @@ function outboundMix (BaseClass) {
         collection.meta = Object.assign({}, collection.meta)
         collection.demand = Object.assign({}, collection.demand)
         collection.entities = yield s.applyOutbound(collection.entities.map(clayEntity), actionContext)
-        return s.toResourceCollection(collection)
+        return s.createResourceCollection(collection)
       })
     }
 


### PR DESCRIPTION
entityそのもの挙動を変えたい時、listやoneの返却値を個別にdecorateするのは大変なので。

```javascript

it('Enhance entity', () => co(function * () {
    const driver = clayDriverMemory()
    const User = fromDriver(driver, 'User')
    User.enhanceResourceEntity((UserEntity) =>
      class EnhancedUserEntity extends UserEntity {
        get fullName () {
          let { familyName, firstName } = this
          return [ firstName, familyName ].filter(Boolean).join(' ')
        }
      }
    )

    let user01 = yield User.create({ firstName: 'Taka', familyName: 'Okunishi' })
    equal(user01.fullName, 'Taka Okunishi')
  }))
```