### PR TITLE
エラーメッセージを丁寧にした

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ class UserResource extends ClayResource {
 API Guide
 -----
 
-+ [clay-resource@3.1.14](./doc/api/api.md)
++ [clay-resource@3.1.15](./doc/api/api.md)
   + [create(args)](./doc/api/api.md#clay-resource-function-create)
   + [fromDriver(driver, nameString, options)](./doc/api/api.md#clay-resource-function-from-driver)
   + [ClayResource](./doc/api/api.md#clay-resource-class)

--- a/ci/doc.js
+++ b/ci/doc.js
@@ -9,27 +9,17 @@
 process.chdir(`${__dirname}/..`)
 
 const apeTasking = require('ape-tasking')
-const co = require('co')
 const coz = require('coz')
-const { execSync } = require('child_process')
-const writeout = require('writeout')
+const jsdoc = require('the-script-jsdoc')
 
 apeTasking.runTasks('doc', [
   // Generate jsdoc.json
-  () => co(function * () {
-    let src = 'lib/*.js lib/mixins/*.js'
+  async () => {
+    let src = [
+      'lib/*.js lib/mixins/*.js'
+    ]
     let dest = 'jsdoc.json'
-    let data = execSync(`
-    jsdoc ${src} -t templates/haruki -d console -q format=JSON
-`)
-    data = JSON.stringify(JSON.parse(data), null, 2)
-    let result = yield writeout(dest, data, {
-      mkdirp: true,
-      skipIfIdentical: true
-    })
-    if (!result.skipped) {
-      console.log(`File generated: ${result.filename}`)
-    }
-  }),
+    await jsdoc(src, dest)
+  },
   () => coz.render('doc/**/.*.bud')
 ], true)

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -1,4 +1,4 @@
-# clay-resource@3.1.14
+# clay-resource@3.1.15
 
 Resource accessor for ClayDB
 
@@ -7,6 +7,26 @@ Resource accessor for ClayDB
   + [fromDriver(driver, nameString, options)](#clay-resource-function-from-driver)
 + [`ClayResource`](#clay-resource-class) Class
   + [new ClayResource(nameString, bounds, options)](#clay-resource-class-clay-resource-constructor)
+  + [resource.one(id, options)](#clay-resource-class-clay-resource-one)
+  + [resource.list(condition)](#clay-resource-class-clay-resource-list)
+  + [resource.create(attributes, options)](#clay-resource-class-clay-resource-create)
+  + [resource.update(id, attributes)](#clay-resource-class-clay-resource-update)
+  + [resource.destroy(id)](#clay-resource-class-clay-resource-destroy)
+  + [resource.drop()](#clay-resource-class-clay-resource-drop)
+  + [resource.oneBulk(ids)](#clay-resource-class-clay-resource-oneBulk)
+  + [resource.listBulk(conditionArray)](#clay-resource-class-clay-resource-listBulk)
+  + [resource.createBulk(attributesArray)](#clay-resource-class-clay-resource-createBulk)
+  + [resource.updateBulk(attributesHash)](#clay-resource-class-clay-resource-updateBulk)
+  + [resource.destroyBulk(ids)](#clay-resource-class-clay-resource-destroyBulk)
+  + [resource.cursor(options)](#clay-resource-class-clay-resource-cursor)
+  + [resource.first(filter, options)](#clay-resource-class-clay-resource-first)
+  + [resource.only(filter, options)](#clay-resource-class-clay-resource-only)
+  + [resource.seal(privateKey, options)](#clay-resource-class-clay-resource-seal)
+  + [resource.has(id)](#clay-resource-class-clay-resource-has)
+  + [resource.exists(filter)](#clay-resource-class-clay-resource-exists)
+  + [resource.count(filter)](#clay-resource-class-clay-resource-count)
+  + [resource.of(attributes)](#clay-resource-class-clay-resource-of)
+  + [resource.all(filter, options)](#clay-resource-class-clay-resource-all)
   + [resource.one(id, options)](#clay-resource-class-clay-resource-one)
   + [resource.list(condition)](#clay-resource-class-clay-resource-list)
   + [resource.create(attributes, options)](#clay-resource-class-clay-resource-create)
@@ -145,6 +165,452 @@ Constructor of ClayResource class
 | options | Object | Optional settings |
 | options.annotates | boolean | Enable annotation |
 | options.refs | Array.&lt;ClayResource&gt; | Add resource refs |
+
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-one" ></a>
+
+### resource.one(id, options) -> `Promise.<Entity>`
+
+Get a resource
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| id | ClayId | Id of the entity |
+| options | Object | Optional settings |
+| options.strict | boolean | If true, throws an error when not found |
+
+**Example**:
+
+```javascript
+const Product = lump.resource('Product')
+async function tryOne () {
+  let product = await Product.one(1) // Find by id
+  console.log(product)
+}
+```
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-list" ></a>
+
+### resource.list(condition) -> `Promise.<Collection>`
+
+List entities from resource
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| condition | ListCondition | List condition query |
+| condition.filter | FilterTerm | Filter condition |
+| condition.page | PagerTerm | Page condition |
+| condition.page.number | number | Number of page, start with 1 |
+| condition.page.size | number | Number of resources per page |
+| condition.sort | SortTerm | Sort condition |
+
+**Example**:
+
+```javascript
+const Product = lump.resource('Product')
+async function tryList () {
+  let products = await Product.list({
+    filter: { type: 'Vehicle' },  // Filter condition
+    page: { number: 1, size: 25 }, // Paginate
+    sort: [ 'createdAt', '-name' ] // Sort condition
+  })
+  console.log(products)
+}
+tryList()
+```
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-create" ></a>
+
+### resource.create(attributes, options) -> `Promise.<Entity>`
+
+Create a new entity with resource
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| attributes | Object | Resource attributes to create |
+| options | Object | Optional settings |
+| options.allowReserved | boolean | Arrow to set reserved attributes (like "id") |
+
+**Example**:
+
+```javascript
+const Product = lump.resource('Product')
+async function tryCreate () {
+  let product = await Product.create({
+    name: 'Super Car',
+    type: 'Vehicle'
+  })
+  console.log(product)
+}
+tryCreate()
+```
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-update" ></a>
+
+### resource.update(id, attributes) -> `Promise.<Entity>`
+
+Update an existing entity in resource
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| id | ClayId | Resource id |
+| attributes | Object | Resource attributes to update |
+
+**Example**:
+
+```javascript
+const Product = lump.resource('Product')
+async function tryUpdate () {
+  let product = await Product.update(1, {
+    name: 'Super Super Car'
+  })
+  console.log(product)
+}
+tryUpdate()
+```
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-destroy" ></a>
+
+### resource.destroy(id) -> `Promise.<number>`
+
+Delete a entity resource
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| id | ClayId | Resource id |
+
+**Example**:
+
+```javascript
+const Product = lump.resource('Product')
+async function tryDestroy () {
+  await Product.destroy(1)
+}
+tryDestroy()
+```
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-drop" ></a>
+
+### resource.drop() -> `Promise.<boolean>`
+
+Drop resource
+**Example**:
+
+```javascript
+const Product = lump.resource('Product')
+async function tryDrop () {
+  await Product.drop()
+}
+tryDrop()
+```
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-oneBulk" ></a>
+
+### resource.oneBulk(ids) -> `Promise.<Object.<ClayId, Entity>>`
+
+One as bulk
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| ids | Array.&lt;ClayId&gt; | Resource ids |
+
+**Example**:
+
+```javascript
+const Product = lump.resource('Product')
+async function tryOneBulk () {
+  let products = await Product.oneBulk([ 1, 5, 10 ])
+  console.log(products)
+}
+tryOneBulk()
+```
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-listBulk" ></a>
+
+### resource.listBulk(conditionArray) -> `Promise.<Array.<Collection>>`
+
+List with multiple conditions
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| conditionArray | Array.&lt;ListCondition&gt; |  |
+
+**Example**:
+
+```javascript
+const Product = lump.resource('Product')
+async function tryListBulk () {
+  let [ cars, ships ] = await Product.listBulk([
+    { filter: { type: 'CAR' } },
+    { filter: { type: 'SHIP' } },
+  ])
+  console.log(cars)
+  console.log(ships)
+}
+tryListBulk()
+```
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-createBulk" ></a>
+
+### resource.createBulk(attributesArray) -> `Promise.<Array.<Entity>>`
+
+Create multiple resources
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| attributesArray | Array.&lt;Object&gt; | List of attributes |
+
+**Example**:
+
+```javascript
+const Product = lump.resource('Product')
+async function tryCreateBulk () {
+  let products = await Product.createBulk([
+    { name: 'Super Orange', type: 'CAR' },
+    { name: 'Ultra Green', type: 'CAR' },
+  ])
+  console.log(products)
+}
+tryCreateBulk()
+```
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-updateBulk" ></a>
+
+### resource.updateBulk(attributesHash) -> `Promise.<Object.<ClayId, Entity>>`
+
+Update multiple resources
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| attributesHash | Object.&lt;ClayId, Object&gt; | Hash of attributes |
+
+**Example**:
+
+```javascript
+const Product = lump.resource('Product')
+async function tryUpdateBulk () {
+  let products = await Product.updateBulk({
+    '1': { name: 'Super Super Orange' },
+    '2': { name: 'Ultra Ultra Green' },
+  })
+  console.log(products)
+}
+tryUpdateBulk()
+```
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-destroyBulk" ></a>
+
+### resource.destroyBulk(ids) -> `Promise.<number>`
+
+Update multiple resources
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| ids | Array.&lt;ClayId&gt; | Ids to destroy |
+
+**Example**:
+
+```javascript
+const Product = lump.resource('Product')
+async function tryDestroyBulk () {
+  await Product.destroyBulk([1, 2])
+})
+tryDestroyBulk()
+```
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-cursor" ></a>
+
+### resource.cursor(options) -> `Object`
+
+Create cursor to cursor
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| options | Object | Optional settings |
+| options.filter | FilterTerm | Filter condition |
+| options.sort | SortTerm | Sort condition |
+
+**Example**:
+
+```javascript
+const Product = lump.resource('Product')
+async function tryCursor () {
+  let cursor = await Product.cursor({
+    filter: { type: 'CAR' }
+  })
+  console.log(cursor.length) // Number of entities matches the condition
+  for (let fetch of cursor) {
+    let car = yield fetch() // Fetch the pointed entity
+    console.log(car)
+  }
+}
+tryCursor()
+```
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-first" ></a>
+
+### resource.first(filter, options) -> `Promise.<?Entity>`
+
+Get the first entity matches filter
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| filter | FilterTerm | Listing filter |
+| options | Object | Optional settings |
+| options.sort | Object | Sort conditions |
+
+**Example**:
+
+```javascript
+const Product = lump.resource('Product')
+async function tryFirst () {
+  let product = Product.first({ name: 'Super Super Orange' })
+  console.log(product)
+}
+tryFirst()
+```
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-only" ></a>
+
+### resource.only(filter, options) -> `Promise.<?Entity>`
+
+Almost same with `.first()`, but throws an error if multiple record hits, or no record found
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| filter | FilterTerm | Listing filter |
+| options | Object | Optional settings |
+| options.strict | boolean | If true, throws an error when not found |
+
+**Example**:
+
+```javascript
+const Product = lump.resource('Product')
+async function tryFirst () {
+  let product = Product.only({ name: 'Super Super Orange' })
+  console.log(product)
+}
+tryFirst()
+```
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-seal" ></a>
+
+### resource.seal(privateKey, options) -> `Promise`
+
+Seal resources
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| privateKey | string | RSA Private key |
+| options | Object | Optional settings |
+| options.by | string | For $$by |
+
+**Example**:
+
+```javascript
+const Product = lump.resource('Product')
+const privateKey = 'xxxxxxxxxxxxxxxxxxxxxxxxx'
+async function trySeal () {
+  await Product.seal(privateKey)
+}
+trySeal()
+```
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-has" ></a>
+
+### resource.has(id) -> `Promise.<boolean>`
+
+Check entity with id exists
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| id | ClayId | Id of the entity |
+
+**Example**:
+
+```javascript
+const Product = lump.resource('Product')
+async function tryHas () {
+  let has = await Product.has(1)
+  console.log(has)
+}
+tryHas()
+```
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-exists" ></a>
+
+### resource.exists(filter) -> `Promise.<boolean>`
+
+Check data exists with filter
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| filter | FilterTerm | List filter |
+
+**Example**:
+
+```javascript
+const Product = lump.resource('Product')
+async function tryExists () {
+  let exists = await Product.exists({ name: 'Super Super Orange' })
+  console.log(exists)
+}
+tryExists()
+```
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-count" ></a>
+
+### resource.count(filter) -> `Promise.<number>`
+
+Count data matches filter
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| filter | FilterTerm | List filter |
+
+**Example**:
+
+```javascript
+const Product = lump.resource('Product')
+async function tryCount () {
+  let count = await Product.count({ type: 'CAR' })
+  console.log(count)
+}
+tryCount()
+```
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-of" ></a>
+
+### resource.of(attributes)
+
+Find entity with attributes and returns if found.
+If not found, create and return the one.
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| attributes | Object | Attributes |
+
+**Example**:
+
+```javascript
+const Product = lump.resource('Product')
+async function tryOf () {
+  let values = await Product.of({ code: '#1234' })
+  console.log(values)
+}
+tryOf()
+```
+
+<a class='md-heading-link' name="clay-resource-class-clay-resource-all" ></a>
+
+### resource.all(filter, options) -> `Promise.<Array.<ClayEntity>>`
+
+Get all entities inside resource which matches the filter
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| filter | FilterTerm | Listing filter |
+| options | Object | Optional settings |
 
 
 <a class='md-heading-link' name="clay-resource-class-clay-resource-one" ></a>

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,3325 +1,6425 @@
 {
-  "classes": [
-    {
-      "name": "ClayResource",
-      "description": "",
-      "extends": [
-        "AnnotateMixed",
-        "CloneMixed",
-        "InboundMixed",
-        "OutboundMixed",
-        "PolicyMixed",
-        "RefMixed",
-        "SubMixed",
-        "ThrowMixed",
-        "InternalMixed",
-        "PrepareMixed",
-        "DecorateMixed",
-        "CacheMixed",
-        "ConditionMixed"
-      ],
-      "access": "",
-      "virtual": false,
-      "fires": "",
-      "constructor": {
-        "name": "ClayResource",
-        "description": "Resource accessor",
-        "parameters": [
-          {
-            "name": "nameString",
-            "type": "string",
-            "description": "Name string",
-            "default": "",
-            "optional": "",
-            "nullable": ""
-          },
-          {
-            "name": "bounds",
-            "type": "Object.<string, function()>",
-            "description": "Method bounds",
-            "default": "",
-            "optional": "",
-            "nullable": ""
-          },
-          {
-            "name": "options",
-            "type": "Object",
-            "description": "Optional settings",
-            "default": "{}",
-            "optional": true,
-            "nullable": ""
-          },
-          {
-            "name": "options.annotates",
-            "type": "boolean",
-            "description": "Enable annotation",
-            "default": "",
-            "optional": true,
-            "nullable": ""
-          },
-          {
-            "name": "options.refs",
-            "type": "Array.<ClayResource>",
-            "description": "Add resource refs",
-            "default": "",
-            "optional": true,
-            "nullable": ""
-          }
-        ],
-        "examples": []
-      },
-      "functions": [
+    "classes": [
         {
-          "name": "one",
-          "access": "",
-          "virtual": false,
-          "description": "Get a resource",
-          "parameters": [
-            {
-              "name": "id",
-              "type": "ClayId",
-              "description": "Id of the entity",
-              "default": "",
-              "optional": "",
-              "nullable": ""
+            "name": "ClayResource",
+            "description": "",
+            "extends": [
+                "AnnotateMixed",
+                "CloneMixed",
+                "InboundMixed",
+                "OutboundMixed",
+                "PolicyMixed",
+                "RefMixed",
+                "SubMixed",
+                "ThrowMixed",
+                "InternalMixed",
+                "PrepareMixed",
+                "DecorateMixed",
+                "CacheMixed",
+                "ConditionMixed"
+            ],
+            "access": "",
+            "virtual": false,
+            "fires": "",
+            "constructor": {
+                "name": "ClayResource",
+                "description": "Resource accessor",
+                "parameters": [
+                    {
+                        "name": "nameString",
+                        "type": "string",
+                        "description": "Name string",
+                        "default": "",
+                        "optional": "",
+                        "nullable": ""
+                    },
+                    {
+                        "name": "bounds",
+                        "type": "Object.<string, function()>",
+                        "description": "Method bounds",
+                        "default": "",
+                        "optional": "",
+                        "nullable": ""
+                    },
+                    {
+                        "name": "options",
+                        "type": "Object",
+                        "description": "Optional settings",
+                        "default": "{}",
+                        "optional": true,
+                        "nullable": ""
+                    },
+                    {
+                        "name": "options.annotates",
+                        "type": "boolean",
+                        "description": "Enable annotation",
+                        "default": "",
+                        "optional": true,
+                        "nullable": ""
+                    },
+                    {
+                        "name": "options.refs",
+                        "type": "Array.<ClayResource>",
+                        "description": "Add resource refs",
+                        "default": "",
+                        "optional": true,
+                        "nullable": ""
+                    }
+                ],
+                "examples": []
             },
-            {
-              "name": "options",
-              "type": "Object",
-              "description": "Optional settings",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
+            "functions": [
+                {
+                    "name": "one",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get a resource",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "Id of the entity",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.strict",
+                            "type": "boolean",
+                            "description": "If true, throws an error when not found",
+                            "default": "",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryOne () {\n  let product = await Product.one(1) // Find by id\n  console.log(product)\n}"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Entity>",
+                        "description": "Found entity"
+                    }
+                },
+                {
+                    "name": "list",
+                    "access": "",
+                    "virtual": false,
+                    "description": "List entities from resource",
+                    "parameters": [
+                        {
+                            "name": "condition",
+                            "type": "ListCondition",
+                            "description": "List condition query",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.filter",
+                            "type": "FilterTerm",
+                            "description": "Filter condition",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.page",
+                            "type": "PagerTerm",
+                            "description": "Page condition",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.page.number",
+                            "type": "number",
+                            "description": "Number of page, start with 1",
+                            "default": 1,
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.page.size",
+                            "type": "number",
+                            "description": "Number of resources per page",
+                            "default": 100,
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.sort",
+                            "type": "SortTerm",
+                            "description": "Sort condition",
+                            "default": "[]",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryList () {\n  let products = await Product.list({\n    filter: { type: 'Vehicle' },  // Filter condition\n    page: { number: 1, size: 25 }, // Paginate\n    sort: [ 'createdAt', '-name' ] // Sort condition\n  })\n  console.log(products)\n}\ntryList()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Collection>",
+                        "description": "Found resource collection"
+                    }
+                },
+                {
+                    "name": "create",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Create a new entity with resource",
+                    "parameters": [
+                        {
+                            "name": "attributes",
+                            "type": "Object",
+                            "description": "Resource attributes to create",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.allowReserved",
+                            "type": "boolean",
+                            "description": "Arrow to set reserved attributes (like \"id\")",
+                            "default": "",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryCreate () {\n  let product = await Product.create({\n    name: 'Super Car',\n    type: 'Vehicle'\n  })\n  console.log(product)\n}\ntryCreate()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Entity>",
+                        "description": "Created data"
+                    }
+                },
+                {
+                    "name": "update",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Update an existing entity in resource",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "Resource id",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "attributes",
+                            "type": "Object",
+                            "description": "Resource attributes to update",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryUpdate () {\n  let product = await Product.update(1, {\n    name: 'Super Super Car'\n  })\n  console.log(product)\n}\ntryUpdate()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Entity>",
+                        "description": "Updated data"
+                    }
+                },
+                {
+                    "name": "destroy",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Delete a entity resource",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "Resource id",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryDestroy () {\n  await Product.destroy(1)\n}\ntryDestroy()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<number>",
+                        "description": "Destroyed count (0 or 1)"
+                    }
+                },
+                {
+                    "name": "drop",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Drop resource",
+                    "parameters": [],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryDrop () {\n  await Product.drop()\n}\ntryDrop()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<boolean>",
+                        "description": "False if there were nothing to drop"
+                    }
+                },
+                {
+                    "name": "oneBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "One as bulk",
+                    "parameters": [
+                        {
+                            "name": "ids",
+                            "type": "Array.<ClayId>",
+                            "description": "Resource ids",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryOneBulk () {\n  let products = await Product.oneBulk([ 1, 5, 10 ])\n  console.log(products)\n}\ntryOneBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Object.<ClayId, Entity>>",
+                        "description": "Found resources"
+                    }
+                },
+                {
+                    "name": "listBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "List with multiple conditions",
+                    "parameters": [
+                        {
+                            "name": "conditionArray",
+                            "type": "Array.<ListCondition>",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryListBulk () {\n  let [ cars, ships ] = await Product.listBulk([\n    { filter: { type: 'CAR' } },\n    { filter: { type: 'SHIP' } },\n  ])\n  console.log(cars)\n  console.log(ships)\n}\ntryListBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Array.<Collection>>",
+                        "description": "Found resource collections"
+                    }
+                },
+                {
+                    "name": "createBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Create multiple resources",
+                    "parameters": [
+                        {
+                            "name": "attributesArray",
+                            "type": "Array.<Object>",
+                            "description": "List of attributes",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryCreateBulk () {\n  let products = await Product.createBulk([\n    { name: 'Super Orange', type: 'CAR' },\n    { name: 'Ultra Green', type: 'CAR' },\n  ])\n  console.log(products)\n}\ntryCreateBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Array.<Entity>>",
+                        "description": "Created resources"
+                    }
+                },
+                {
+                    "name": "updateBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Update multiple resources",
+                    "parameters": [
+                        {
+                            "name": "attributesHash",
+                            "type": "Object.<ClayId, Object>",
+                            "description": "Hash of attributes",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryUpdateBulk () {\n  let products = await Product.updateBulk({\n    '1': { name: 'Super Super Orange' },\n    '2': { name: 'Ultra Ultra Green' },\n  })\n  console.log(products)\n}\ntryUpdateBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Object.<ClayId, Entity>>",
+                        "description": "Updated resources"
+                    }
+                },
+                {
+                    "name": "destroyBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Update multiple resources",
+                    "parameters": [
+                        {
+                            "name": "ids",
+                            "type": "Array.<ClayId>",
+                            "description": "Ids to destroy",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryDestroyBulk () {\n  await Product.destroyBulk([1, 2])\n})\ntryDestroyBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<number>",
+                        "description": "Destroyed counts"
+                    }
+                },
+                {
+                    "name": "cursor",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Create cursor to cursor",
+                    "parameters": [
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.filter",
+                            "type": "FilterTerm",
+                            "description": "Filter condition",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.sort",
+                            "type": "SortTerm",
+                            "description": "Sort condition",
+                            "default": "[]",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryCursor () {\n  let cursor = await Product.cursor({\n    filter: { type: 'CAR' }\n  })\n  console.log(cursor.length) // Number of entities matches the condition\n  for (let fetch of cursor) {\n    let car = yield fetch() // Fetch the pointed entity\n    console.log(car)\n  }\n}\ntryCursor()"
+                    ],
+                    "returns": {
+                        "type": "Object",
+                        "description": "{Promise.<[Symbol.iterator], function>} Iterable cursor"
+                    }
+                },
+                {
+                    "name": "first",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get the first entity matches filter",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "Listing filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.sort",
+                            "type": "Object",
+                            "description": "Sort conditions",
+                            "default": "[]",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryFirst () {\n  let product = Product.first({ name: 'Super Super Orange' })\n  console.log(product)\n}\ntryFirst()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<?Entity>",
+                        "description": "Found one"
+                    }
+                },
+                {
+                    "name": "only",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Almost same with `.first()`, but throws an error if multiple record hits, or no record found",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "Listing filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.strict",
+                            "type": "boolean",
+                            "description": "If true, throws an error when not found",
+                            "default": "",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryFirst () {\n  let product = Product.only({ name: 'Super Super Orange' })\n  console.log(product)\n}\ntryFirst()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<?Entity>",
+                        "description": "Found one"
+                    }
+                },
+                {
+                    "name": "seal",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Seal resources",
+                    "parameters": [
+                        {
+                            "name": "privateKey",
+                            "type": "string",
+                            "description": "RSA Private key",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.by",
+                            "type": "string",
+                            "description": "For $$by",
+                            "default": null,
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nconst privateKey = 'xxxxxxxxxxxxxxxxxxxxxxxxx'\nasync function trySeal () {\n  await Product.seal(privateKey)\n}\ntrySeal()"
+                    ],
+                    "returns": {
+                        "type": "Promise",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "has",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Check entity with id exists",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "Id of the entity",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryHas () {\n  let has = await Product.has(1)\n  console.log(has)\n}\ntryHas()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<boolean>",
+                        "description": "Exists or not"
+                    }
+                },
+                {
+                    "name": "exists",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Check data exists with filter",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "List filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryExists () {\n  let exists = await Product.exists({ name: 'Super Super Orange' })\n  console.log(exists)\n}\ntryExists()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<boolean>",
+                        "description": "Exists or not"
+                    }
+                },
+                {
+                    "name": "count",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Count data matches filter",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "List filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryCount () {\n  let count = await Product.count({ type: 'CAR' })\n  console.log(count)\n}\ntryCount()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<number>",
+                        "description": "Number of entities"
+                    }
+                },
+                {
+                    "name": "of",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Find entity with attributes and returns if found.\nIf not found, create and return the one.",
+                    "parameters": [
+                        {
+                            "name": "attributes",
+                            "type": "Object",
+                            "description": "Attributes",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryOf () {\n  let values = await Product.of({ code: '#1234' })\n  console.log(values)\n}\ntryOf()"
+                    ]
+                },
+                {
+                    "name": "all",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get all entities inside resource which matches the filter",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "Listing filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<ClayEntity>>",
+                        "description": "Entities"
+                    }
+                },
+                {
+                    "name": "one",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get a resource",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "Id of the entity",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.strict",
+                            "type": "boolean",
+                            "description": "If true, throws an error when not found",
+                            "default": "",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryOne () {\n  let product = await Product.one(1) // Find by id\n  console.log(product)\n}"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Entity>",
+                        "description": "Found entity"
+                    }
+                },
+                {
+                    "name": "list",
+                    "access": "",
+                    "virtual": false,
+                    "description": "List entities from resource",
+                    "parameters": [
+                        {
+                            "name": "condition",
+                            "type": "ListCondition",
+                            "description": "List condition query",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.filter",
+                            "type": "FilterTerm",
+                            "description": "Filter condition",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.page",
+                            "type": "PagerTerm",
+                            "description": "Page condition",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.page.number",
+                            "type": "number",
+                            "description": "Number of page, start with 1",
+                            "default": 1,
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.page.size",
+                            "type": "number",
+                            "description": "Number of resources per page",
+                            "default": 100,
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.sort",
+                            "type": "SortTerm",
+                            "description": "Sort condition",
+                            "default": "[]",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryList () {\n  let products = await Product.list({\n    filter: { type: 'Vehicle' },  // Filter condition\n    page: { number: 1, size: 25 }, // Paginate\n    sort: [ 'createdAt', '-name' ] // Sort condition\n  })\n  console.log(products)\n}\ntryList()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Collection>",
+                        "description": "Found resource collection"
+                    }
+                },
+                {
+                    "name": "create",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Create a new entity with resource",
+                    "parameters": [
+                        {
+                            "name": "attributes",
+                            "type": "Object",
+                            "description": "Resource attributes to create",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.allowReserved",
+                            "type": "boolean",
+                            "description": "Arrow to set reserved attributes (like \"id\")",
+                            "default": "",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryCreate () {\n  let product = await Product.create({\n    name: 'Super Car',\n    type: 'Vehicle'\n  })\n  console.log(product)\n}\ntryCreate()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Entity>",
+                        "description": "Created data"
+                    }
+                },
+                {
+                    "name": "update",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Update an existing entity in resource",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "Resource id",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "attributes",
+                            "type": "Object",
+                            "description": "Resource attributes to update",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryUpdate () {\n  let product = await Product.update(1, {\n    name: 'Super Super Car'\n  })\n  console.log(product)\n}\ntryUpdate()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Entity>",
+                        "description": "Updated data"
+                    }
+                },
+                {
+                    "name": "destroy",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Delete a entity resource",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "Resource id",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryDestroy () {\n  await Product.destroy(1)\n}\ntryDestroy()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<number>",
+                        "description": "Destroyed count (0 or 1)"
+                    }
+                },
+                {
+                    "name": "drop",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Drop resource",
+                    "parameters": [],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryDrop () {\n  await Product.drop()\n}\ntryDrop()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<boolean>",
+                        "description": "False if there were nothing to drop"
+                    }
+                },
+                {
+                    "name": "oneBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "One as bulk",
+                    "parameters": [
+                        {
+                            "name": "ids",
+                            "type": "Array.<ClayId>",
+                            "description": "Resource ids",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryOneBulk () {\n  let products = await Product.oneBulk([ 1, 5, 10 ])\n  console.log(products)\n}\ntryOneBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Object.<ClayId, Entity>>",
+                        "description": "Found resources"
+                    }
+                },
+                {
+                    "name": "listBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "List with multiple conditions",
+                    "parameters": [
+                        {
+                            "name": "conditionArray",
+                            "type": "Array.<ListCondition>",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryListBulk () {\n  let [ cars, ships ] = await Product.listBulk([\n    { filter: { type: 'CAR' } },\n    { filter: { type: 'SHIP' } },\n  ])\n  console.log(cars)\n  console.log(ships)\n}\ntryListBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Array.<Collection>>",
+                        "description": "Found resource collections"
+                    }
+                },
+                {
+                    "name": "createBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Create multiple resources",
+                    "parameters": [
+                        {
+                            "name": "attributesArray",
+                            "type": "Array.<Object>",
+                            "description": "List of attributes",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryCreateBulk () {\n  let products = await Product.createBulk([\n    { name: 'Super Orange', type: 'CAR' },\n    { name: 'Ultra Green', type: 'CAR' },\n  ])\n  console.log(products)\n}\ntryCreateBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Array.<Entity>>",
+                        "description": "Created resources"
+                    }
+                },
+                {
+                    "name": "updateBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Update multiple resources",
+                    "parameters": [
+                        {
+                            "name": "attributesHash",
+                            "type": "Object.<ClayId, Object>",
+                            "description": "Hash of attributes",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryUpdateBulk () {\n  let products = await Product.updateBulk({\n    '1': { name: 'Super Super Orange' },\n    '2': { name: 'Ultra Ultra Green' },\n  })\n  console.log(products)\n}\ntryUpdateBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Object.<ClayId, Entity>>",
+                        "description": "Updated resources"
+                    }
+                },
+                {
+                    "name": "destroyBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Update multiple resources",
+                    "parameters": [
+                        {
+                            "name": "ids",
+                            "type": "Array.<ClayId>",
+                            "description": "Ids to destroy",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryDestroyBulk () {\n  await Product.destroyBulk([1, 2])\n})\ntryDestroyBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<number>",
+                        "description": "Destroyed counts"
+                    }
+                },
+                {
+                    "name": "cursor",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Create cursor to cursor",
+                    "parameters": [
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.filter",
+                            "type": "FilterTerm",
+                            "description": "Filter condition",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.sort",
+                            "type": "SortTerm",
+                            "description": "Sort condition",
+                            "default": "[]",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryCursor () {\n  let cursor = await Product.cursor({\n    filter: { type: 'CAR' }\n  })\n  console.log(cursor.length) // Number of entities matches the condition\n  for (let fetch of cursor) {\n    let car = yield fetch() // Fetch the pointed entity\n    console.log(car)\n  }\n}\ntryCursor()"
+                    ],
+                    "returns": {
+                        "type": "Object",
+                        "description": "{Promise.<[Symbol.iterator], function>} Iterable cursor"
+                    }
+                },
+                {
+                    "name": "first",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get the first entity matches filter",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "Listing filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.sort",
+                            "type": "Object",
+                            "description": "Sort conditions",
+                            "default": "[]",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryFirst () {\n  let product = Product.first({ name: 'Super Super Orange' })\n  console.log(product)\n}\ntryFirst()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<?Entity>",
+                        "description": "Found one"
+                    }
+                },
+                {
+                    "name": "only",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Almost same with `.first()`, but throws an error if multiple record hits, or no record found",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "Listing filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.strict",
+                            "type": "boolean",
+                            "description": "If true, throws an error when not found",
+                            "default": "",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryFirst () {\n  let product = Product.only({ name: 'Super Super Orange' })\n  console.log(product)\n}\ntryFirst()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<?Entity>",
+                        "description": "Found one"
+                    }
+                },
+                {
+                    "name": "seal",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Seal resources",
+                    "parameters": [
+                        {
+                            "name": "privateKey",
+                            "type": "string",
+                            "description": "RSA Private key",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.by",
+                            "type": "string",
+                            "description": "For $$by",
+                            "default": null,
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nconst privateKey = 'xxxxxxxxxxxxxxxxxxxxxxxxx'\nasync function trySeal () {\n  await Product.seal(privateKey)\n}\ntrySeal()"
+                    ],
+                    "returns": {
+                        "type": "Promise",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "has",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Check entity with id exists",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "Id of the entity",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryHas () {\n  let has = await Product.has(1)\n  console.log(has)\n}\ntryHas()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<boolean>",
+                        "description": "Exists or not"
+                    }
+                },
+                {
+                    "name": "exists",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Check data exists with filter",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "List filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryExists () {\n  let exists = await Product.exists({ name: 'Super Super Orange' })\n  console.log(exists)\n}\ntryExists()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<boolean>",
+                        "description": "Exists or not"
+                    }
+                },
+                {
+                    "name": "count",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Count data matches filter",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "List filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryCount () {\n  let count = await Product.count({ type: 'CAR' })\n  console.log(count)\n}\ntryCount()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<number>",
+                        "description": "Number of entities"
+                    }
+                },
+                {
+                    "name": "of",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Find entity with attributes and returns if found.\nIf not found, create and return the one.",
+                    "parameters": [
+                        {
+                            "name": "attributes",
+                            "type": "Object",
+                            "description": "Attributes",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryOf () {\n  let values = await Product.of({ code: '#1234' })\n  console.log(values)\n}\ntryOf()"
+                    ]
+                },
+                {
+                    "name": "all",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get all entities inside resource which matches the filter",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "Listing filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<ClayEntity>>",
+                        "description": "Entities"
+                    }
+                },
+                {
+                    "name": "toggleAnnotate",
+                    "access": "",
+                    "virtual": false,
+                    "description": "",
+                    "parameters": [],
+                    "examples": []
+                },
+                {
+                    "name": "clone",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Clone the instance",
+                    "parameters": [],
+                    "examples": [],
+                    "returns": {
+                        "type": "Object",
+                        "description": "Cloned instance"
+                    }
+                },
+                {
+                    "name": "addInbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Add inbound",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of inbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "inbound",
+                            "type": "function",
+                            "description": "Inbound function",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "InboundMixed",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "hasInbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Check if has inbound",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of inbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "boolean",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "removeInbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Remove inbound",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of inbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "InboundMixed",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "applyInbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Apply inbound to array of attributes",
+                    "parameters": [
+                        {
+                            "name": "attributesArray",
+                            "type": "Array.<EntityAttributes>",
+                            "description": "Array of attributes",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "ActionContext",
+                            "description": "Context for resource action",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<EntityAttributes>>",
+                        "description": "Inbounded attributes array"
+                    }
+                },
+                {
+                    "name": "inboundAttributes",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Inbound attributes",
+                    "parameters": [
+                        {
+                            "name": "attributes",
+                            "type": "EntityAttributes",
+                            "description": "Attributes to inbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "ActionContext",
+                            "description": "Context for resource action",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<EntityAttributes>",
+                        "description": "Inbounded attributes"
+                    }
+                },
+                {
+                    "name": "inboundAttributesArray",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Inbound attributes array",
+                    "parameters": [
+                        {
+                            "name": "attributesArray",
+                            "type": "Array.<EntityAttributes>",
+                            "description": "Attributes array to inbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "ActionContext",
+                            "description": "Context for resource action",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<EntityAttributes>>",
+                        "description": "Inbounded attributes array"
+                    }
+                },
+                {
+                    "name": "inboundAttributesHash",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Inbound attributes hash",
+                    "parameters": [
+                        {
+                            "name": "attributesHash",
+                            "type": "AttributesHash",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "ActionContext",
+                            "description": "Context for resource action",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<AttributesHash>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "addOutbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Add outbound",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of outbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "handler",
+                            "type": "function",
+                            "description": "Format handler function",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "OutboundMixed",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "hasOutbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Check if has outbound",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of outbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "boolean",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "removeOutbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Remove outbound",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of outbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "OutboundMixed",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "applyOutbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Apply outbound to entities",
+                    "parameters": [
+                        {
+                            "name": "entities",
+                            "type": "Array.<Entity>",
+                            "description": "Entities to outbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "Object",
+                            "description": "",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<Entity>>",
+                        "description": "Formatted entities"
+                    }
+                },
+                {
+                    "name": "outboundEntity",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Format entity",
+                    "parameters": [
+                        {
+                            "name": "entity",
+                            "type": "Entity",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "Object",
+                            "description": "",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Entity>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "outboundEntityArray",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Proses entity array",
+                    "parameters": [
+                        {
+                            "name": "entityArray",
+                            "type": "Array.<Entity>",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "Object",
+                            "description": "",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<Entity>>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "outboundCollection",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Format entity collection",
+                    "parameters": [
+                        {
+                            "name": "collection",
+                            "type": "Collection",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "Object",
+                            "description": "",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Collection>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "outboundEntityHash",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Format entity hash",
+                    "parameters": [
+                        {
+                            "name": "entityHash",
+                            "type": "EntityHash",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "Object",
+                            "description": "",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<EntityHash>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "outboundCollectionArray",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Format collection array",
+                    "parameters": [
+                        {
+                            "name": "collectionArray",
+                            "type": "CollectionArray",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "Object",
+                            "description": "",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<CollectionArray>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "getPolicy",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get the policy",
+                    "parameters": [],
+                    "examples": [],
+                    "returns": {
+                        "type": "ClayPolicy",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "setPolicy",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Set policy",
+                    "parameters": [
+                        {
+                            "name": "policy",
+                            "type": "",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "PolicyMix",
+                        "description": "this"
+                    }
+                },
+                {
+                    "name": "removePolicy",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Remove policy",
+                    "parameters": [],
+                    "examples": []
+                },
+                {
+                    "name": "fetchPolicy",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Fetch policy from db",
+                    "parameters": [
+                        {
+                            "name": "digest",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<ClayPolicy>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "savePolicy",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Save policy",
+                    "parameters": [
+                        {
+                            "name": "policy",
+                            "type": "ClayPolicy",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<string>",
+                        "description": "Digest of saved policy"
+                    }
+                },
+                {
+                    "name": "addRef",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Add resource ref",
+                    "parameters": [
+                        {
+                            "name": "resourceName",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "resource",
+                            "type": "ClayResource",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": []
+                },
+                {
+                    "name": "hasRef",
+                    "access": "",
+                    "virtual": false,
+                    "description": "has resources ref",
+                    "parameters": [
+                        {
+                            "name": "resourceName",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "boolean",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "removeRef",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Remove resource ref",
+                    "parameters": [
+                        {
+                            "name": "resourceName",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "FormatMix",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "sub",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get sub resource",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "ClayResource",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "subNames",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get names of sub resources",
+                    "parameters": [],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<string>>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "throwEntityNotFoundError",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Throw entity not found error",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": []
+                },
+                {
+                    "name": "internal",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get internal resource",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "ClayResource",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "internalNames",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get names of internal resources",
+                    "parameters": [],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<string>>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "prepareIfNeeded",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Do prepare if needed",
+                    "parameters": [],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "prepare",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Do preparing",
+                    "parameters": [],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Object>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "addPrepareTask",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Add prepare task",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of task",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "task",
+                            "type": "function",
+                            "description": "Task function",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "PrepareMixed",
+                        "description": "Returns this"
+                    }
+                },
+                {
+                    "name": "hasPrepareTask",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Check if has task",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "boolean",
+                        "description": "Has or not"
+                    }
+                },
+                {
+                    "name": "removePrepareTask",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Remove a task",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of task",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "PrepareMixed",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "setNeedsPrepare",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Set needs prepare",
+                    "parameters": [
+                        {
+                            "name": "needsPrepare",
+                            "type": "boolean",
+                            "description": "Needs preparing",
+                            "default": true,
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "PrepareMixed",
+                        "description": "Returns self"
+                    }
+                },
+                {
+                    "name": "decorate",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Decorate a method",
+                    "parameters": [
+                        {
+                            "name": "methodName",
+                            "type": "string",
+                            "description": "Name of method",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "decorate",
+                            "type": "function",
+                            "description": "Decorate function",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "DecorateMixed",
+                        "description": "Returns this"
+                    }
+                },
+                {
+                    "name": "caches",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Toggle caching",
+                    "parameters": [
+                        {
+                            "name": "caches",
+                            "type": "boolean",
+                            "description": "Should cache or not",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "CacheMixed",
+                        "description": "this"
+                    }
+                },
+                {
+                    "name": "storeCache",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Store an entity into cache",
+                    "parameters": [
+                        {
+                            "name": "entity",
+                            "type": "",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": []
+                },
+                {
+                    "name": "gainCache",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Gain entity from cache",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": []
+                },
+                {
+                    "name": "requestCacheClear",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Request cache clear",
+                    "parameters": [
+                        {
+                            "name": "ids",
+                            "type": [
+                                "ClayId",
+                                "Array.<ClayId>"
+                            ],
+                            "description": "Ids to clear",
+                            "default": "",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": []
+                },
+                {
+                    "name": "parseCondition",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Parse list condition",
+                    "parameters": [
+                        {
+                            "name": "condition",
+                            "type": "ListCondition",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "ListCondition",
+                        "description": "- Parsed condition"
+                    }
+                },
+                {
+                    "name": "parseConditionArray",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Parse list condition array",
+                    "parameters": [
+                        {
+                            "name": "conditionArray",
+                            "type": "Array.<ListCondition>",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Array.<ListCondition>",
+                        "description": "- Parsed condition array"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "ClayResource",
+            "description": "",
+            "extends": [
+                "AnnotateMixed",
+                "CloneMixed",
+                "InboundMixed",
+                "OutboundMixed",
+                "PolicyMixed",
+                "RefMixed",
+                "SubMixed",
+                "ThrowMixed",
+                "InternalMixed",
+                "PrepareMixed",
+                "DecorateMixed",
+                "CacheMixed",
+                "ConditionMixed"
+            ],
+            "access": "",
+            "virtual": false,
+            "fires": "",
+            "constructor": {
+                "name": "ClayResource",
+                "description": "Resource accessor",
+                "parameters": [
+                    {
+                        "name": "nameString",
+                        "type": "string",
+                        "description": "Name string",
+                        "default": "",
+                        "optional": "",
+                        "nullable": ""
+                    },
+                    {
+                        "name": "bounds",
+                        "type": "Object.<string, function()>",
+                        "description": "Method bounds",
+                        "default": "",
+                        "optional": "",
+                        "nullable": ""
+                    },
+                    {
+                        "name": "options",
+                        "type": "Object",
+                        "description": "Optional settings",
+                        "default": "{}",
+                        "optional": true,
+                        "nullable": ""
+                    },
+                    {
+                        "name": "options.annotates",
+                        "type": "boolean",
+                        "description": "Enable annotation",
+                        "default": "",
+                        "optional": true,
+                        "nullable": ""
+                    },
+                    {
+                        "name": "options.refs",
+                        "type": "Array.<ClayResource>",
+                        "description": "Add resource refs",
+                        "default": "",
+                        "optional": true,
+                        "nullable": ""
+                    }
+                ],
+                "examples": []
             },
-            {
-              "name": "options.strict",
-              "type": "boolean",
-              "description": "If true, throws an error when not found",
-              "default": "",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [
-            "const Product = lump.resource('Product')\nasync function tryOne () {\n  let product = await Product.one(1) // Find by id\n  console.log(product)\n}"
-          ],
-          "returns": {
-            "type": "Promise.<Entity>",
-            "description": "Found entity"
-          }
+            "functions": [
+                {
+                    "name": "one",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get a resource",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "Id of the entity",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.strict",
+                            "type": "boolean",
+                            "description": "If true, throws an error when not found",
+                            "default": "",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryOne () {\n  let product = await Product.one(1) // Find by id\n  console.log(product)\n}"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Entity>",
+                        "description": "Found entity"
+                    }
+                },
+                {
+                    "name": "list",
+                    "access": "",
+                    "virtual": false,
+                    "description": "List entities from resource",
+                    "parameters": [
+                        {
+                            "name": "condition",
+                            "type": "ListCondition",
+                            "description": "List condition query",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.filter",
+                            "type": "FilterTerm",
+                            "description": "Filter condition",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.page",
+                            "type": "PagerTerm",
+                            "description": "Page condition",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.page.number",
+                            "type": "number",
+                            "description": "Number of page, start with 1",
+                            "default": 1,
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.page.size",
+                            "type": "number",
+                            "description": "Number of resources per page",
+                            "default": 100,
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.sort",
+                            "type": "SortTerm",
+                            "description": "Sort condition",
+                            "default": "[]",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryList () {\n  let products = await Product.list({\n    filter: { type: 'Vehicle' },  // Filter condition\n    page: { number: 1, size: 25 }, // Paginate\n    sort: [ 'createdAt', '-name' ] // Sort condition\n  })\n  console.log(products)\n}\ntryList()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Collection>",
+                        "description": "Found resource collection"
+                    }
+                },
+                {
+                    "name": "create",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Create a new entity with resource",
+                    "parameters": [
+                        {
+                            "name": "attributes",
+                            "type": "Object",
+                            "description": "Resource attributes to create",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.allowReserved",
+                            "type": "boolean",
+                            "description": "Arrow to set reserved attributes (like \"id\")",
+                            "default": "",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryCreate () {\n  let product = await Product.create({\n    name: 'Super Car',\n    type: 'Vehicle'\n  })\n  console.log(product)\n}\ntryCreate()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Entity>",
+                        "description": "Created data"
+                    }
+                },
+                {
+                    "name": "update",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Update an existing entity in resource",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "Resource id",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "attributes",
+                            "type": "Object",
+                            "description": "Resource attributes to update",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryUpdate () {\n  let product = await Product.update(1, {\n    name: 'Super Super Car'\n  })\n  console.log(product)\n}\ntryUpdate()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Entity>",
+                        "description": "Updated data"
+                    }
+                },
+                {
+                    "name": "destroy",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Delete a entity resource",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "Resource id",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryDestroy () {\n  await Product.destroy(1)\n}\ntryDestroy()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<number>",
+                        "description": "Destroyed count (0 or 1)"
+                    }
+                },
+                {
+                    "name": "drop",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Drop resource",
+                    "parameters": [],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryDrop () {\n  await Product.drop()\n}\ntryDrop()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<boolean>",
+                        "description": "False if there were nothing to drop"
+                    }
+                },
+                {
+                    "name": "oneBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "One as bulk",
+                    "parameters": [
+                        {
+                            "name": "ids",
+                            "type": "Array.<ClayId>",
+                            "description": "Resource ids",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryOneBulk () {\n  let products = await Product.oneBulk([ 1, 5, 10 ])\n  console.log(products)\n}\ntryOneBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Object.<ClayId, Entity>>",
+                        "description": "Found resources"
+                    }
+                },
+                {
+                    "name": "listBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "List with multiple conditions",
+                    "parameters": [
+                        {
+                            "name": "conditionArray",
+                            "type": "Array.<ListCondition>",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryListBulk () {\n  let [ cars, ships ] = await Product.listBulk([\n    { filter: { type: 'CAR' } },\n    { filter: { type: 'SHIP' } },\n  ])\n  console.log(cars)\n  console.log(ships)\n}\ntryListBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Array.<Collection>>",
+                        "description": "Found resource collections"
+                    }
+                },
+                {
+                    "name": "createBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Create multiple resources",
+                    "parameters": [
+                        {
+                            "name": "attributesArray",
+                            "type": "Array.<Object>",
+                            "description": "List of attributes",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryCreateBulk () {\n  let products = await Product.createBulk([\n    { name: 'Super Orange', type: 'CAR' },\n    { name: 'Ultra Green', type: 'CAR' },\n  ])\n  console.log(products)\n}\ntryCreateBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Array.<Entity>>",
+                        "description": "Created resources"
+                    }
+                },
+                {
+                    "name": "updateBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Update multiple resources",
+                    "parameters": [
+                        {
+                            "name": "attributesHash",
+                            "type": "Object.<ClayId, Object>",
+                            "description": "Hash of attributes",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryUpdateBulk () {\n  let products = await Product.updateBulk({\n    '1': { name: 'Super Super Orange' },\n    '2': { name: 'Ultra Ultra Green' },\n  })\n  console.log(products)\n}\ntryUpdateBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Object.<ClayId, Entity>>",
+                        "description": "Updated resources"
+                    }
+                },
+                {
+                    "name": "destroyBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Update multiple resources",
+                    "parameters": [
+                        {
+                            "name": "ids",
+                            "type": "Array.<ClayId>",
+                            "description": "Ids to destroy",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryDestroyBulk () {\n  await Product.destroyBulk([1, 2])\n})\ntryDestroyBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<number>",
+                        "description": "Destroyed counts"
+                    }
+                },
+                {
+                    "name": "cursor",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Create cursor to cursor",
+                    "parameters": [
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.filter",
+                            "type": "FilterTerm",
+                            "description": "Filter condition",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.sort",
+                            "type": "SortTerm",
+                            "description": "Sort condition",
+                            "default": "[]",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryCursor () {\n  let cursor = await Product.cursor({\n    filter: { type: 'CAR' }\n  })\n  console.log(cursor.length) // Number of entities matches the condition\n  for (let fetch of cursor) {\n    let car = yield fetch() // Fetch the pointed entity\n    console.log(car)\n  }\n}\ntryCursor()"
+                    ],
+                    "returns": {
+                        "type": "Object",
+                        "description": "{Promise.<[Symbol.iterator], function>} Iterable cursor"
+                    }
+                },
+                {
+                    "name": "first",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get the first entity matches filter",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "Listing filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.sort",
+                            "type": "Object",
+                            "description": "Sort conditions",
+                            "default": "[]",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryFirst () {\n  let product = Product.first({ name: 'Super Super Orange' })\n  console.log(product)\n}\ntryFirst()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<?Entity>",
+                        "description": "Found one"
+                    }
+                },
+                {
+                    "name": "only",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Almost same with `.first()`, but throws an error if multiple record hits, or no record found",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "Listing filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.strict",
+                            "type": "boolean",
+                            "description": "If true, throws an error when not found",
+                            "default": "",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryFirst () {\n  let product = Product.only({ name: 'Super Super Orange' })\n  console.log(product)\n}\ntryFirst()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<?Entity>",
+                        "description": "Found one"
+                    }
+                },
+                {
+                    "name": "seal",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Seal resources",
+                    "parameters": [
+                        {
+                            "name": "privateKey",
+                            "type": "string",
+                            "description": "RSA Private key",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.by",
+                            "type": "string",
+                            "description": "For $$by",
+                            "default": null,
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nconst privateKey = 'xxxxxxxxxxxxxxxxxxxxxxxxx'\nasync function trySeal () {\n  await Product.seal(privateKey)\n}\ntrySeal()"
+                    ],
+                    "returns": {
+                        "type": "Promise",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "has",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Check entity with id exists",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "Id of the entity",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryHas () {\n  let has = await Product.has(1)\n  console.log(has)\n}\ntryHas()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<boolean>",
+                        "description": "Exists or not"
+                    }
+                },
+                {
+                    "name": "exists",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Check data exists with filter",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "List filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryExists () {\n  let exists = await Product.exists({ name: 'Super Super Orange' })\n  console.log(exists)\n}\ntryExists()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<boolean>",
+                        "description": "Exists or not"
+                    }
+                },
+                {
+                    "name": "count",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Count data matches filter",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "List filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryCount () {\n  let count = await Product.count({ type: 'CAR' })\n  console.log(count)\n}\ntryCount()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<number>",
+                        "description": "Number of entities"
+                    }
+                },
+                {
+                    "name": "of",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Find entity with attributes and returns if found.\nIf not found, create and return the one.",
+                    "parameters": [
+                        {
+                            "name": "attributes",
+                            "type": "Object",
+                            "description": "Attributes",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryOf () {\n  let values = await Product.of({ code: '#1234' })\n  console.log(values)\n}\ntryOf()"
+                    ]
+                },
+                {
+                    "name": "all",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get all entities inside resource which matches the filter",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "Listing filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<ClayEntity>>",
+                        "description": "Entities"
+                    }
+                },
+                {
+                    "name": "one",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get a resource",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "Id of the entity",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.strict",
+                            "type": "boolean",
+                            "description": "If true, throws an error when not found",
+                            "default": "",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryOne () {\n  let product = await Product.one(1) // Find by id\n  console.log(product)\n}"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Entity>",
+                        "description": "Found entity"
+                    }
+                },
+                {
+                    "name": "list",
+                    "access": "",
+                    "virtual": false,
+                    "description": "List entities from resource",
+                    "parameters": [
+                        {
+                            "name": "condition",
+                            "type": "ListCondition",
+                            "description": "List condition query",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.filter",
+                            "type": "FilterTerm",
+                            "description": "Filter condition",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.page",
+                            "type": "PagerTerm",
+                            "description": "Page condition",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.page.number",
+                            "type": "number",
+                            "description": "Number of page, start with 1",
+                            "default": 1,
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.page.size",
+                            "type": "number",
+                            "description": "Number of resources per page",
+                            "default": 100,
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "condition.sort",
+                            "type": "SortTerm",
+                            "description": "Sort condition",
+                            "default": "[]",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryList () {\n  let products = await Product.list({\n    filter: { type: 'Vehicle' },  // Filter condition\n    page: { number: 1, size: 25 }, // Paginate\n    sort: [ 'createdAt', '-name' ] // Sort condition\n  })\n  console.log(products)\n}\ntryList()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Collection>",
+                        "description": "Found resource collection"
+                    }
+                },
+                {
+                    "name": "create",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Create a new entity with resource",
+                    "parameters": [
+                        {
+                            "name": "attributes",
+                            "type": "Object",
+                            "description": "Resource attributes to create",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.allowReserved",
+                            "type": "boolean",
+                            "description": "Arrow to set reserved attributes (like \"id\")",
+                            "default": "",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryCreate () {\n  let product = await Product.create({\n    name: 'Super Car',\n    type: 'Vehicle'\n  })\n  console.log(product)\n}\ntryCreate()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Entity>",
+                        "description": "Created data"
+                    }
+                },
+                {
+                    "name": "update",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Update an existing entity in resource",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "Resource id",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "attributes",
+                            "type": "Object",
+                            "description": "Resource attributes to update",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryUpdate () {\n  let product = await Product.update(1, {\n    name: 'Super Super Car'\n  })\n  console.log(product)\n}\ntryUpdate()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Entity>",
+                        "description": "Updated data"
+                    }
+                },
+                {
+                    "name": "destroy",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Delete a entity resource",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "Resource id",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryDestroy () {\n  await Product.destroy(1)\n}\ntryDestroy()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<number>",
+                        "description": "Destroyed count (0 or 1)"
+                    }
+                },
+                {
+                    "name": "drop",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Drop resource",
+                    "parameters": [],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryDrop () {\n  await Product.drop()\n}\ntryDrop()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<boolean>",
+                        "description": "False if there were nothing to drop"
+                    }
+                },
+                {
+                    "name": "oneBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "One as bulk",
+                    "parameters": [
+                        {
+                            "name": "ids",
+                            "type": "Array.<ClayId>",
+                            "description": "Resource ids",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryOneBulk () {\n  let products = await Product.oneBulk([ 1, 5, 10 ])\n  console.log(products)\n}\ntryOneBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Object.<ClayId, Entity>>",
+                        "description": "Found resources"
+                    }
+                },
+                {
+                    "name": "listBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "List with multiple conditions",
+                    "parameters": [
+                        {
+                            "name": "conditionArray",
+                            "type": "Array.<ListCondition>",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryListBulk () {\n  let [ cars, ships ] = await Product.listBulk([\n    { filter: { type: 'CAR' } },\n    { filter: { type: 'SHIP' } },\n  ])\n  console.log(cars)\n  console.log(ships)\n}\ntryListBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Array.<Collection>>",
+                        "description": "Found resource collections"
+                    }
+                },
+                {
+                    "name": "createBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Create multiple resources",
+                    "parameters": [
+                        {
+                            "name": "attributesArray",
+                            "type": "Array.<Object>",
+                            "description": "List of attributes",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryCreateBulk () {\n  let products = await Product.createBulk([\n    { name: 'Super Orange', type: 'CAR' },\n    { name: 'Ultra Green', type: 'CAR' },\n  ])\n  console.log(products)\n}\ntryCreateBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Array.<Entity>>",
+                        "description": "Created resources"
+                    }
+                },
+                {
+                    "name": "updateBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Update multiple resources",
+                    "parameters": [
+                        {
+                            "name": "attributesHash",
+                            "type": "Object.<ClayId, Object>",
+                            "description": "Hash of attributes",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryUpdateBulk () {\n  let products = await Product.updateBulk({\n    '1': { name: 'Super Super Orange' },\n    '2': { name: 'Ultra Ultra Green' },\n  })\n  console.log(products)\n}\ntryUpdateBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<Object.<ClayId, Entity>>",
+                        "description": "Updated resources"
+                    }
+                },
+                {
+                    "name": "destroyBulk",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Update multiple resources",
+                    "parameters": [
+                        {
+                            "name": "ids",
+                            "type": "Array.<ClayId>",
+                            "description": "Ids to destroy",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryDestroyBulk () {\n  await Product.destroyBulk([1, 2])\n})\ntryDestroyBulk()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<number>",
+                        "description": "Destroyed counts"
+                    }
+                },
+                {
+                    "name": "cursor",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Create cursor to cursor",
+                    "parameters": [
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.filter",
+                            "type": "FilterTerm",
+                            "description": "Filter condition",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.sort",
+                            "type": "SortTerm",
+                            "description": "Sort condition",
+                            "default": "[]",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryCursor () {\n  let cursor = await Product.cursor({\n    filter: { type: 'CAR' }\n  })\n  console.log(cursor.length) // Number of entities matches the condition\n  for (let fetch of cursor) {\n    let car = yield fetch() // Fetch the pointed entity\n    console.log(car)\n  }\n}\ntryCursor()"
+                    ],
+                    "returns": {
+                        "type": "Object",
+                        "description": "{Promise.<[Symbol.iterator], function>} Iterable cursor"
+                    }
+                },
+                {
+                    "name": "first",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get the first entity matches filter",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "Listing filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.sort",
+                            "type": "Object",
+                            "description": "Sort conditions",
+                            "default": "[]",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryFirst () {\n  let product = Product.first({ name: 'Super Super Orange' })\n  console.log(product)\n}\ntryFirst()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<?Entity>",
+                        "description": "Found one"
+                    }
+                },
+                {
+                    "name": "only",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Almost same with `.first()`, but throws an error if multiple record hits, or no record found",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "Listing filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.strict",
+                            "type": "boolean",
+                            "description": "If true, throws an error when not found",
+                            "default": "",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryFirst () {\n  let product = Product.only({ name: 'Super Super Orange' })\n  console.log(product)\n}\ntryFirst()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<?Entity>",
+                        "description": "Found one"
+                    }
+                },
+                {
+                    "name": "seal",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Seal resources",
+                    "parameters": [
+                        {
+                            "name": "privateKey",
+                            "type": "string",
+                            "description": "RSA Private key",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options.by",
+                            "type": "string",
+                            "description": "For $$by",
+                            "default": null,
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nconst privateKey = 'xxxxxxxxxxxxxxxxxxxxxxxxx'\nasync function trySeal () {\n  await Product.seal(privateKey)\n}\ntrySeal()"
+                    ],
+                    "returns": {
+                        "type": "Promise",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "has",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Check entity with id exists",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "Id of the entity",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryHas () {\n  let has = await Product.has(1)\n  console.log(has)\n}\ntryHas()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<boolean>",
+                        "description": "Exists or not"
+                    }
+                },
+                {
+                    "name": "exists",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Check data exists with filter",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "List filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryExists () {\n  let exists = await Product.exists({ name: 'Super Super Orange' })\n  console.log(exists)\n}\ntryExists()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<boolean>",
+                        "description": "Exists or not"
+                    }
+                },
+                {
+                    "name": "count",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Count data matches filter",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "List filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryCount () {\n  let count = await Product.count({ type: 'CAR' })\n  console.log(count)\n}\ntryCount()"
+                    ],
+                    "returns": {
+                        "type": "Promise.<number>",
+                        "description": "Number of entities"
+                    }
+                },
+                {
+                    "name": "of",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Find entity with attributes and returns if found.\nIf not found, create and return the one.",
+                    "parameters": [
+                        {
+                            "name": "attributes",
+                            "type": "Object",
+                            "description": "Attributes",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [
+                        "const Product = lump.resource('Product')\nasync function tryOf () {\n  let values = await Product.of({ code: '#1234' })\n  console.log(values)\n}\ntryOf()"
+                    ]
+                },
+                {
+                    "name": "all",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get all entities inside resource which matches the filter",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "type": "FilterTerm",
+                            "description": "Listing filter",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        },
+                        {
+                            "name": "options",
+                            "type": "Object",
+                            "description": "Optional settings",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<ClayEntity>>",
+                        "description": "Entities"
+                    }
+                },
+                {
+                    "name": "toggleAnnotate",
+                    "access": "",
+                    "virtual": false,
+                    "description": "",
+                    "parameters": [],
+                    "examples": []
+                },
+                {
+                    "name": "clone",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Clone the instance",
+                    "parameters": [],
+                    "examples": [],
+                    "returns": {
+                        "type": "Object",
+                        "description": "Cloned instance"
+                    }
+                },
+                {
+                    "name": "addInbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Add inbound",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of inbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "inbound",
+                            "type": "function",
+                            "description": "Inbound function",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "InboundMixed",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "hasInbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Check if has inbound",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of inbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "boolean",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "removeInbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Remove inbound",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of inbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "InboundMixed",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "applyInbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Apply inbound to array of attributes",
+                    "parameters": [
+                        {
+                            "name": "attributesArray",
+                            "type": "Array.<EntityAttributes>",
+                            "description": "Array of attributes",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "ActionContext",
+                            "description": "Context for resource action",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<EntityAttributes>>",
+                        "description": "Inbounded attributes array"
+                    }
+                },
+                {
+                    "name": "inboundAttributes",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Inbound attributes",
+                    "parameters": [
+                        {
+                            "name": "attributes",
+                            "type": "EntityAttributes",
+                            "description": "Attributes to inbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "ActionContext",
+                            "description": "Context for resource action",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<EntityAttributes>",
+                        "description": "Inbounded attributes"
+                    }
+                },
+                {
+                    "name": "inboundAttributesArray",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Inbound attributes array",
+                    "parameters": [
+                        {
+                            "name": "attributesArray",
+                            "type": "Array.<EntityAttributes>",
+                            "description": "Attributes array to inbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "ActionContext",
+                            "description": "Context for resource action",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<EntityAttributes>>",
+                        "description": "Inbounded attributes array"
+                    }
+                },
+                {
+                    "name": "inboundAttributesHash",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Inbound attributes hash",
+                    "parameters": [
+                        {
+                            "name": "attributesHash",
+                            "type": "AttributesHash",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "ActionContext",
+                            "description": "Context for resource action",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<AttributesHash>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "addOutbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Add outbound",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of outbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "handler",
+                            "type": "function",
+                            "description": "Format handler function",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "OutboundMixed",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "hasOutbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Check if has outbound",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of outbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "boolean",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "removeOutbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Remove outbound",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of outbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "OutboundMixed",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "applyOutbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Apply outbound to entities",
+                    "parameters": [
+                        {
+                            "name": "entities",
+                            "type": "Array.<Entity>",
+                            "description": "Entities to outbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "Object",
+                            "description": "",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<Entity>>",
+                        "description": "Formatted entities"
+                    }
+                },
+                {
+                    "name": "outboundEntity",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Format entity",
+                    "parameters": [
+                        {
+                            "name": "entity",
+                            "type": "Entity",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "Object",
+                            "description": "",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Entity>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "outboundEntityArray",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Proses entity array",
+                    "parameters": [
+                        {
+                            "name": "entityArray",
+                            "type": "Array.<Entity>",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "Object",
+                            "description": "",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<Entity>>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "outboundCollection",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Format entity collection",
+                    "parameters": [
+                        {
+                            "name": "collection",
+                            "type": "Collection",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "Object",
+                            "description": "",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Collection>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "outboundEntityHash",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Format entity hash",
+                    "parameters": [
+                        {
+                            "name": "entityHash",
+                            "type": "EntityHash",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "Object",
+                            "description": "",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<EntityHash>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "outboundCollectionArray",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Format collection array",
+                    "parameters": [
+                        {
+                            "name": "collectionArray",
+                            "type": "CollectionArray",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "Object",
+                            "description": "",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<CollectionArray>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "getPolicy",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get the policy",
+                    "parameters": [],
+                    "examples": [],
+                    "returns": {
+                        "type": "ClayPolicy",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "setPolicy",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Set policy",
+                    "parameters": [
+                        {
+                            "name": "policy",
+                            "type": "",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "PolicyMix",
+                        "description": "this"
+                    }
+                },
+                {
+                    "name": "removePolicy",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Remove policy",
+                    "parameters": [],
+                    "examples": []
+                },
+                {
+                    "name": "fetchPolicy",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Fetch policy from db",
+                    "parameters": [
+                        {
+                            "name": "digest",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<ClayPolicy>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "savePolicy",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Save policy",
+                    "parameters": [
+                        {
+                            "name": "policy",
+                            "type": "ClayPolicy",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<string>",
+                        "description": "Digest of saved policy"
+                    }
+                },
+                {
+                    "name": "addRef",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Add resource ref",
+                    "parameters": [
+                        {
+                            "name": "resourceName",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "resource",
+                            "type": "ClayResource",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": []
+                },
+                {
+                    "name": "hasRef",
+                    "access": "",
+                    "virtual": false,
+                    "description": "has resources ref",
+                    "parameters": [
+                        {
+                            "name": "resourceName",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "boolean",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "removeRef",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Remove resource ref",
+                    "parameters": [
+                        {
+                            "name": "resourceName",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "FormatMix",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "sub",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get sub resource",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "ClayResource",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "subNames",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get names of sub resources",
+                    "parameters": [],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<string>>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "throwEntityNotFoundError",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Throw entity not found error",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": []
+                },
+                {
+                    "name": "internal",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get internal resource",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "ClayResource",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "internalNames",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get names of internal resources",
+                    "parameters": [],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<string>>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "prepareIfNeeded",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Do prepare if needed",
+                    "parameters": [],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "prepare",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Do preparing",
+                    "parameters": [],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Object>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "addPrepareTask",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Add prepare task",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of task",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "task",
+                            "type": "function",
+                            "description": "Task function",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "PrepareMixed",
+                        "description": "Returns this"
+                    }
+                },
+                {
+                    "name": "hasPrepareTask",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Check if has task",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "boolean",
+                        "description": "Has or not"
+                    }
+                },
+                {
+                    "name": "removePrepareTask",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Remove a task",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of task",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "PrepareMixed",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "setNeedsPrepare",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Set needs prepare",
+                    "parameters": [
+                        {
+                            "name": "needsPrepare",
+                            "type": "boolean",
+                            "description": "Needs preparing",
+                            "default": true,
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "PrepareMixed",
+                        "description": "Returns self"
+                    }
+                },
+                {
+                    "name": "decorate",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Decorate a method",
+                    "parameters": [
+                        {
+                            "name": "methodName",
+                            "type": "string",
+                            "description": "Name of method",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "decorate",
+                            "type": "function",
+                            "description": "Decorate function",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "DecorateMixed",
+                        "description": "Returns this"
+                    }
+                },
+                {
+                    "name": "caches",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Toggle caching",
+                    "parameters": [
+                        {
+                            "name": "caches",
+                            "type": "boolean",
+                            "description": "Should cache or not",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "CacheMixed",
+                        "description": "this"
+                    }
+                },
+                {
+                    "name": "storeCache",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Store an entity into cache",
+                    "parameters": [
+                        {
+                            "name": "entity",
+                            "type": "",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": []
+                },
+                {
+                    "name": "gainCache",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Gain entity from cache",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": []
+                },
+                {
+                    "name": "requestCacheClear",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Request cache clear",
+                    "parameters": [
+                        {
+                            "name": "ids",
+                            "type": [
+                                "ClayId",
+                                "Array.<ClayId>"
+                            ],
+                            "description": "Ids to clear",
+                            "default": "",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": []
+                },
+                {
+                    "name": "parseCondition",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Parse list condition",
+                    "parameters": [
+                        {
+                            "name": "condition",
+                            "type": "ListCondition",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "ListCondition",
+                        "description": "- Parsed condition"
+                    }
+                },
+                {
+                    "name": "parseConditionArray",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Parse list condition array",
+                    "parameters": [
+                        {
+                            "name": "conditionArray",
+                            "type": "Array.<ListCondition>",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Array.<ListCondition>",
+                        "description": "- Parsed condition array"
+                    }
+                }
+            ]
         },
         {
-          "name": "list",
-          "access": "",
-          "virtual": false,
-          "description": "List entities from resource",
-          "parameters": [
-            {
-              "name": "condition",
-              "type": "ListCondition",
-              "description": "List condition query",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
+            "name": "AnnotateMixed",
+            "description": "",
+            "extends": [],
+            "access": "",
+            "virtual": false,
+            "fires": "",
+            "constructor": {
+                "name": "AnnotateMixed",
+                "description": "",
+                "parameters": [],
+                "examples": []
             },
-            {
-              "name": "condition.filter",
-              "type": "FilterTerm",
-              "description": "Filter condition",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
+            "functions": [
+                {
+                    "name": "toggleAnnotate",
+                    "access": "",
+                    "virtual": false,
+                    "description": "",
+                    "parameters": [],
+                    "examples": []
+                }
+            ]
+        },
+        {
+            "name": "CacheMixed",
+            "description": "",
+            "extends": [],
+            "access": "",
+            "virtual": false,
+            "fires": "",
+            "constructor": {
+                "name": "CacheMixed",
+                "description": "",
+                "parameters": [],
+                "examples": []
             },
-            {
-              "name": "condition.page",
-              "type": "PagerTerm",
-              "description": "Page condition",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
+            "functions": [
+                {
+                    "name": "caches",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Toggle caching",
+                    "parameters": [
+                        {
+                            "name": "caches",
+                            "type": "boolean",
+                            "description": "Should cache or not",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "CacheMixed",
+                        "description": "this"
+                    }
+                },
+                {
+                    "name": "storeCache",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Store an entity into cache",
+                    "parameters": [
+                        {
+                            "name": "entity",
+                            "type": "",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": []
+                },
+                {
+                    "name": "gainCache",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Gain entity from cache",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": []
+                },
+                {
+                    "name": "requestCacheClear",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Request cache clear",
+                    "parameters": [
+                        {
+                            "name": "ids",
+                            "type": [
+                                "ClayId",
+                                "Array.<ClayId>"
+                            ],
+                            "description": "Ids to clear",
+                            "default": "",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": []
+                }
+            ]
+        },
+        {
+            "name": "CloneMixed",
+            "description": "",
+            "extends": [],
+            "access": "",
+            "virtual": false,
+            "fires": "",
+            "constructor": {
+                "name": "CloneMixed",
+                "description": "",
+                "parameters": [],
+                "examples": []
             },
-            {
-              "name": "condition.page.number",
-              "type": "number",
-              "description": "Number of page, start with 1",
-              "default": 1,
-              "optional": true,
-              "nullable": ""
+            "functions": [
+                {
+                    "name": "clone",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Clone the instance",
+                    "parameters": [],
+                    "examples": [],
+                    "returns": {
+                        "type": "Object",
+                        "description": "Cloned instance"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "CollectionMixed",
+            "description": "",
+            "extends": [],
+            "access": "",
+            "virtual": false,
+            "fires": "",
+            "constructor": {
+                "name": "CollectionMixed",
+                "description": "",
+                "parameters": [],
+                "examples": []
             },
-            {
-              "name": "condition.page.size",
-              "type": "number",
-              "description": "Number of resources per page",
-              "default": 100,
-              "optional": true,
-              "nullable": ""
+            "functions": [
+                {
+                    "name": "createResourceCollection",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Convert collection into resource collection",
+                    "parameters": [
+                        {
+                            "name": "collection",
+                            "type": "Collection",
+                            "description": "Collection to convert",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "CollectionMixed.ResourceCollection",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "enhanceResourceCollection",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Extend resource collection",
+                    "parameters": [
+                        {
+                            "name": "enhancer",
+                            "type": "function",
+                            "description": "Enhancer function",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "EntityMixed",
+                        "description": "Returns this for chaining"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "ConditionMixed",
+            "description": "",
+            "extends": [],
+            "access": "",
+            "virtual": false,
+            "fires": "",
+            "constructor": {
+                "name": "ConditionMixed",
+                "description": "",
+                "parameters": [],
+                "examples": []
             },
-            {
-              "name": "condition.sort",
-              "type": "SortTerm",
-              "description": "Sort condition",
-              "default": "[]",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [
-            "const Product = lump.resource('Product')\nasync function tryList () {\n  let products = await Product.list({\n    filter: { type: 'Vehicle' },  // Filter condition\n    page: { number: 1, size: 25 }, // Paginate\n    sort: [ 'createdAt', '-name' ] // Sort condition\n  })\n  console.log(products)\n}\ntryList()"
-          ],
-          "returns": {
-            "type": "Promise.<Collection>",
-            "description": "Found resource collection"
-          }
+            "functions": [
+                {
+                    "name": "parseCondition",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Parse list condition",
+                    "parameters": [
+                        {
+                            "name": "condition",
+                            "type": "ListCondition",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "ListCondition",
+                        "description": "- Parsed condition"
+                    }
+                },
+                {
+                    "name": "parseConditionArray",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Parse list condition array",
+                    "parameters": [
+                        {
+                            "name": "conditionArray",
+                            "type": "Array.<ListCondition>",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Array.<ListCondition>",
+                        "description": "- Parsed condition array"
+                    }
+                }
+            ]
         },
         {
-          "name": "create",
-          "access": "",
-          "virtual": false,
-          "description": "Create a new entity with resource",
-          "parameters": [
-            {
-              "name": "attributes",
-              "type": "Object",
-              "description": "Resource attributes to create",
-              "default": "",
-              "optional": "",
-              "nullable": ""
+            "name": "DecorateMixed",
+            "description": "",
+            "extends": [],
+            "access": "",
+            "virtual": false,
+            "fires": "",
+            "constructor": {
+                "name": "DecorateMixed",
+                "description": "",
+                "parameters": [],
+                "examples": []
             },
-            {
-              "name": "options",
-              "type": "Object",
-              "description": "Optional settings",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
+            "functions": [
+                {
+                    "name": "decorate",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Decorate a method",
+                    "parameters": [
+                        {
+                            "name": "methodName",
+                            "type": "string",
+                            "description": "Name of method",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "decorate",
+                            "type": "function",
+                            "description": "Decorate function",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "DecorateMixed",
+                        "description": "Returns this"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "EntityMixed",
+            "description": "",
+            "extends": [],
+            "access": "",
+            "virtual": false,
+            "fires": "",
+            "constructor": {
+                "name": "EntityMixed",
+                "description": "",
+                "parameters": [],
+                "examples": []
             },
-            {
-              "name": "options.allowReserved",
-              "type": "boolean",
-              "description": "Arrow to set reserved attributes (like \"id\")",
-              "default": "",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [
-            "const Product = lump.resource('Product')\nasync function tryCreate () {\n  let product = await Product.create({\n    name: 'Super Car',\n    type: 'Vehicle'\n  })\n  console.log(product)\n}\ntryCreate()"
-          ],
-          "returns": {
-            "type": "Promise.<Entity>",
-            "description": "Created data"
-          }
+            "functions": [
+                {
+                    "name": "createResourceEntity",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Convert entity into resource entity",
+                    "parameters": [
+                        {
+                            "name": "entity",
+                            "type": "Entity",
+                            "description": "to convert",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "EntityMixed.ResourceEntity",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "enhanceResourceEntity",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Extend resource entity",
+                    "parameters": [
+                        {
+                            "name": "enhancer",
+                            "type": "function",
+                            "description": "Enhancer function",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "EntityMixed",
+                        "description": "Returns this for chaining"
+                    }
+                }
+            ]
         },
         {
-          "name": "update",
-          "access": "",
-          "virtual": false,
-          "description": "Update an existing entity in resource",
-          "parameters": [
-            {
-              "name": "id",
-              "type": "ClayId",
-              "description": "Resource id",
-              "default": "",
-              "optional": "",
-              "nullable": ""
+            "name": "InboundMixed",
+            "description": "",
+            "extends": [],
+            "access": "",
+            "virtual": false,
+            "fires": "",
+            "constructor": {
+                "name": "InboundMixed",
+                "description": "",
+                "parameters": [],
+                "examples": []
             },
-            {
-              "name": "attributes",
-              "type": "Object",
-              "description": "Resource attributes to update",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [
-            "const Product = lump.resource('Product')\nasync function tryUpdate () {\n  let product = await Product.update(1, {\n    name: 'Super Super Car'\n  })\n  console.log(product)\n}\ntryUpdate()"
-          ],
-          "returns": {
-            "type": "Promise.<Entity>",
-            "description": "Updated data"
-          }
+            "functions": [
+                {
+                    "name": "addInbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Add inbound",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of inbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "inbound",
+                            "type": "function",
+                            "description": "Inbound function",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "InboundMixed",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "hasInbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Check if has inbound",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of inbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "boolean",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "removeInbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Remove inbound",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of inbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "InboundMixed",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "applyInbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Apply inbound to array of attributes",
+                    "parameters": [
+                        {
+                            "name": "attributesArray",
+                            "type": "Array.<EntityAttributes>",
+                            "description": "Array of attributes",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "ActionContext",
+                            "description": "Context for resource action",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<EntityAttributes>>",
+                        "description": "Inbounded attributes array"
+                    }
+                },
+                {
+                    "name": "inboundAttributes",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Inbound attributes",
+                    "parameters": [
+                        {
+                            "name": "attributes",
+                            "type": "EntityAttributes",
+                            "description": "Attributes to inbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "ActionContext",
+                            "description": "Context for resource action",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<EntityAttributes>",
+                        "description": "Inbounded attributes"
+                    }
+                },
+                {
+                    "name": "inboundAttributesArray",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Inbound attributes array",
+                    "parameters": [
+                        {
+                            "name": "attributesArray",
+                            "type": "Array.<EntityAttributes>",
+                            "description": "Attributes array to inbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "ActionContext",
+                            "description": "Context for resource action",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<EntityAttributes>>",
+                        "description": "Inbounded attributes array"
+                    }
+                },
+                {
+                    "name": "inboundAttributesHash",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Inbound attributes hash",
+                    "parameters": [
+                        {
+                            "name": "attributesHash",
+                            "type": "AttributesHash",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "ActionContext",
+                            "description": "Context for resource action",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<AttributesHash>",
+                        "description": ""
+                    }
+                }
+            ]
         },
         {
-          "name": "destroy",
-          "access": "",
-          "virtual": false,
-          "description": "Delete a entity resource",
-          "parameters": [
-            {
-              "name": "id",
-              "type": "ClayId",
-              "description": "Resource id",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [
-            "const Product = lump.resource('Product')\nasync function tryDestroy () {\n  await Product.destroy(1)\n}\ntryDestroy()"
-          ],
-          "returns": {
-            "type": "Promise.<number>",
-            "description": "Destroyed count (0 or 1)"
-          }
-        },
-        {
-          "name": "drop",
-          "access": "",
-          "virtual": false,
-          "description": "Drop resource",
-          "parameters": [],
-          "examples": [
-            "const Product = lump.resource('Product')\nasync function tryDrop () {\n  await Product.drop()\n}\ntryDrop()"
-          ],
-          "returns": {
-            "type": "Promise.<boolean>",
-            "description": "False if there were nothing to drop"
-          }
-        },
-        {
-          "name": "oneBulk",
-          "access": "",
-          "virtual": false,
-          "description": "One as bulk",
-          "parameters": [
-            {
-              "name": "ids",
-              "type": "Array.<ClayId>",
-              "description": "Resource ids",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [
-            "const Product = lump.resource('Product')\nasync function tryOneBulk () {\n  let products = await Product.oneBulk([ 1, 5, 10 ])\n  console.log(products)\n}\ntryOneBulk()"
-          ],
-          "returns": {
-            "type": "Promise.<Object.<ClayId, Entity>>",
-            "description": "Found resources"
-          }
-        },
-        {
-          "name": "listBulk",
-          "access": "",
-          "virtual": false,
-          "description": "List with multiple conditions",
-          "parameters": [
-            {
-              "name": "conditionArray",
-              "type": "Array.<ListCondition>",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [
-            "const Product = lump.resource('Product')\nasync function tryListBulk () {\n  let [ cars, ships ] = await Product.listBulk([\n    { filter: { type: 'CAR' } },\n    { filter: { type: 'SHIP' } },\n  ])\n  console.log(cars)\n  console.log(ships)\n}\ntryListBulk()"
-          ],
-          "returns": {
-            "type": "Promise.<Array.<Collection>>",
-            "description": "Found resource collections"
-          }
-        },
-        {
-          "name": "createBulk",
-          "access": "",
-          "virtual": false,
-          "description": "Create multiple resources",
-          "parameters": [
-            {
-              "name": "attributesArray",
-              "type": "Array.<Object>",
-              "description": "List of attributes",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [
-            "const Product = lump.resource('Product')\nasync function tryCreateBulk () {\n  let products = await Product.createBulk([\n    { name: 'Super Orange', type: 'CAR' },\n    { name: 'Ultra Green', type: 'CAR' },\n  ])\n  console.log(products)\n}\ntryCreateBulk()"
-          ],
-          "returns": {
-            "type": "Promise.<Array.<Entity>>",
-            "description": "Created resources"
-          }
-        },
-        {
-          "name": "updateBulk",
-          "access": "",
-          "virtual": false,
-          "description": "Update multiple resources",
-          "parameters": [
-            {
-              "name": "attributesHash",
-              "type": "Object.<ClayId, Object>",
-              "description": "Hash of attributes",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [
-            "const Product = lump.resource('Product')\nasync function tryUpdateBulk () {\n  let products = await Product.updateBulk({\n    '1': { name: 'Super Super Orange' },\n    '2': { name: 'Ultra Ultra Green' },\n  })\n  console.log(products)\n}\ntryUpdateBulk()"
-          ],
-          "returns": {
-            "type": "Promise.<Object.<ClayId, Entity>>",
-            "description": "Updated resources"
-          }
-        },
-        {
-          "name": "destroyBulk",
-          "access": "",
-          "virtual": false,
-          "description": "Update multiple resources",
-          "parameters": [
-            {
-              "name": "ids",
-              "type": "Array.<ClayId>",
-              "description": "Ids to destroy",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [
-            "const Product = lump.resource('Product')\nasync function tryDestroyBulk () {\n  await Product.destroyBulk([1, 2])\n})\ntryDestroyBulk()"
-          ],
-          "returns": {
-            "type": "Promise.<number>",
-            "description": "Destroyed counts"
-          }
-        },
-        {
-          "name": "cursor",
-          "access": "",
-          "virtual": false,
-          "description": "Create cursor to cursor",
-          "parameters": [
-            {
-              "name": "options",
-              "type": "Object",
-              "description": "Optional settings",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
+            "name": "InternalMixed",
+            "description": "",
+            "extends": [],
+            "access": "",
+            "virtual": false,
+            "fires": "",
+            "constructor": {
+                "name": "InternalMixed",
+                "description": "",
+                "parameters": [],
+                "examples": []
             },
-            {
-              "name": "options.filter",
-              "type": "FilterTerm",
-              "description": "Filter condition",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
+            "functions": [
+                {
+                    "name": "internal",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get internal resource",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "ClayResource",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "internalNames",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get names of internal resources",
+                    "parameters": [],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<string>>",
+                        "description": ""
+                    }
+                }
+            ]
+        },
+        {
+            "name": "OutboundMixed",
+            "description": "",
+            "extends": [],
+            "access": "",
+            "virtual": false,
+            "fires": "",
+            "constructor": {
+                "name": "OutboundMixed",
+                "description": "",
+                "parameters": [],
+                "examples": []
             },
-            {
-              "name": "options.sort",
-              "type": "SortTerm",
-              "description": "Sort condition",
-              "default": "[]",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [
-            "const Product = lump.resource('Product')\nasync function tryCursor () {\n  let cursor = await Product.cursor({\n    filter: { type: 'CAR' }\n  })\n  console.log(cursor.length) // Number of entities matches the condition\n  for (let fetch of cursor) {\n    let car = yield fetch() // Fetch the pointed entity\n    console.log(car)\n  }\n}\ntryCursor()"
-          ],
-          "returns": {
-            "type": "Object",
-            "description": "{Promise.<[Symbol.iterator], function>} Iterable cursor"
-          }
+            "functions": [
+                {
+                    "name": "addOutbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Add outbound",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of outbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "handler",
+                            "type": "function",
+                            "description": "Format handler function",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "OutboundMixed",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "hasOutbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Check if has outbound",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of outbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "boolean",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "removeOutbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Remove outbound",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of outbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "OutboundMixed",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "applyOutbound",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Apply outbound to entities",
+                    "parameters": [
+                        {
+                            "name": "entities",
+                            "type": "Array.<Entity>",
+                            "description": "Entities to outbound",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "Object",
+                            "description": "",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<Entity>>",
+                        "description": "Formatted entities"
+                    }
+                },
+                {
+                    "name": "outboundEntity",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Format entity",
+                    "parameters": [
+                        {
+                            "name": "entity",
+                            "type": "Entity",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "Object",
+                            "description": "",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Entity>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "outboundEntityArray",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Proses entity array",
+                    "parameters": [
+                        {
+                            "name": "entityArray",
+                            "type": "Array.<Entity>",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "Object",
+                            "description": "",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<Entity>>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "outboundCollection",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Format entity collection",
+                    "parameters": [
+                        {
+                            "name": "collection",
+                            "type": "Collection",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "Object",
+                            "description": "",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Collection>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "outboundEntityHash",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Format entity hash",
+                    "parameters": [
+                        {
+                            "name": "entityHash",
+                            "type": "EntityHash",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "Object",
+                            "description": "",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<EntityHash>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "outboundCollectionArray",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Format collection array",
+                    "parameters": [
+                        {
+                            "name": "collectionArray",
+                            "type": "CollectionArray",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "actionContext",
+                            "type": "Object",
+                            "description": "",
+                            "default": "{}",
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<CollectionArray>",
+                        "description": ""
+                    }
+                }
+            ]
         },
         {
-          "name": "first",
-          "access": "",
-          "virtual": false,
-          "description": "Get the first entity matches filter",
-          "parameters": [
-            {
-              "name": "filter",
-              "type": "FilterTerm",
-              "description": "Listing filter",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
+            "name": "PolicyMixed",
+            "description": "",
+            "extends": [],
+            "access": "",
+            "virtual": false,
+            "fires": "",
+            "constructor": {
+                "name": "PolicyMixed",
+                "description": "",
+                "parameters": [],
+                "examples": []
             },
-            {
-              "name": "options",
-              "type": "Object",
-              "description": "Optional settings",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
+            "functions": [
+                {
+                    "name": "getPolicy",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get the policy",
+                    "parameters": [],
+                    "examples": [],
+                    "returns": {
+                        "type": "ClayPolicy",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "setPolicy",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Set policy",
+                    "parameters": [
+                        {
+                            "name": "policy",
+                            "type": "",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "PolicyMix",
+                        "description": "this"
+                    }
+                },
+                {
+                    "name": "removePolicy",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Remove policy",
+                    "parameters": [],
+                    "examples": []
+                },
+                {
+                    "name": "fetchPolicy",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Fetch policy from db",
+                    "parameters": [
+                        {
+                            "name": "digest",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<ClayPolicy>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "savePolicy",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Save policy",
+                    "parameters": [
+                        {
+                            "name": "policy",
+                            "type": "ClayPolicy",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<string>",
+                        "description": "Digest of saved policy"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "PrepareMixed",
+            "description": "",
+            "extends": [],
+            "access": "",
+            "virtual": false,
+            "fires": "",
+            "constructor": {
+                "name": "PrepareMixed",
+                "description": "",
+                "parameters": [],
+                "examples": []
             },
-            {
-              "name": "options.sort",
-              "type": "Object",
-              "description": "Sort conditions",
-              "default": "[]",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [
-            "const Product = lump.resource('Product')\nasync function tryFirst () {\n  let product = Product.first({ name: 'Super Super Orange' })\n  console.log(product)\n}\ntryFirst()"
-          ],
-          "returns": {
-            "type": "Promise.<?Entity>",
-            "description": "Found one"
-          }
+            "functions": [
+                {
+                    "name": "prepareIfNeeded",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Do prepare if needed",
+                    "parameters": [],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "prepare",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Do preparing",
+                    "parameters": [],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Object>",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "addPrepareTask",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Add prepare task",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of task",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "task",
+                            "type": "function",
+                            "description": "Task function",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "PrepareMixed",
+                        "description": "Returns this"
+                    }
+                },
+                {
+                    "name": "hasPrepareTask",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Check if has task",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "boolean",
+                        "description": "Has or not"
+                    }
+                },
+                {
+                    "name": "removePrepareTask",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Remove a task",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "Name of task",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "PrepareMixed",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "setNeedsPrepare",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Set needs prepare",
+                    "parameters": [
+                        {
+                            "name": "needsPrepare",
+                            "type": "boolean",
+                            "description": "Needs preparing",
+                            "default": true,
+                            "optional": true,
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "PrepareMixed",
+                        "description": "Returns self"
+                    }
+                }
+            ]
         },
         {
-          "name": "only",
-          "access": "",
-          "virtual": false,
-          "description": "Almost same with `.first()`, but throws an error if multiple record hits, or no record found",
-          "parameters": [
-            {
-              "name": "filter",
-              "type": "FilterTerm",
-              "description": "Listing filter",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
+            "name": "RefMixed",
+            "description": "",
+            "extends": [],
+            "access": "",
+            "virtual": false,
+            "fires": "",
+            "constructor": {
+                "name": "RefMixed",
+                "description": "",
+                "parameters": [],
+                "examples": []
             },
-            {
-              "name": "options",
-              "type": "Object",
-              "description": "Optional settings",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
+            "functions": [
+                {
+                    "name": "addRef",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Add resource ref",
+                    "parameters": [
+                        {
+                            "name": "resourceName",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        },
+                        {
+                            "name": "resource",
+                            "type": "ClayResource",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": []
+                },
+                {
+                    "name": "hasRef",
+                    "access": "",
+                    "virtual": false,
+                    "description": "has resources ref",
+                    "parameters": [
+                        {
+                            "name": "resourceName",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "boolean",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "removeRef",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Remove resource ref",
+                    "parameters": [
+                        {
+                            "name": "resourceName",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "FormatMix",
+                        "description": ""
+                    }
+                }
+            ]
+        },
+        {
+            "name": "SubMixed",
+            "description": "",
+            "extends": [],
+            "access": "",
+            "virtual": false,
+            "fires": "",
+            "constructor": {
+                "name": "SubMixed",
+                "description": "",
+                "parameters": [],
+                "examples": []
             },
-            {
-              "name": "options.strict",
-              "type": "boolean",
-              "description": "If true, throws an error when not found",
-              "default": "",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [
-            "const Product = lump.resource('Product')\nasync function tryFirst () {\n  let product = Product.only({ name: 'Super Super Orange' })\n  console.log(product)\n}\ntryFirst()"
-          ],
-          "returns": {
-            "type": "Promise.<?Entity>",
-            "description": "Found one"
-          }
+            "functions": [
+                {
+                    "name": "sub",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get sub resource",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": [],
+                    "returns": {
+                        "type": "ClayResource",
+                        "description": ""
+                    }
+                },
+                {
+                    "name": "subNames",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Get names of sub resources",
+                    "parameters": [],
+                    "examples": [],
+                    "returns": {
+                        "type": "Promise.<Array.<string>>",
+                        "description": ""
+                    }
+                }
+            ]
         },
         {
-          "name": "seal",
-          "access": "",
-          "virtual": false,
-          "description": "Seal resources",
-          "parameters": [
-            {
-              "name": "privateKey",
-              "type": "string",
-              "description": "RSA Private key",
-              "default": "",
-              "optional": "",
-              "nullable": ""
+            "name": "ThrowMixed",
+            "description": "",
+            "extends": [],
+            "access": "",
+            "virtual": false,
+            "fires": "",
+            "constructor": {
+                "name": "ThrowMixed",
+                "description": "",
+                "parameters": [],
+                "examples": []
             },
-            {
-              "name": "options",
-              "type": "Object",
-              "description": "Optional settings",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            },
-            {
-              "name": "options.by",
-              "type": "string",
-              "description": "For $$by",
-              "default": null,
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [
-            "const Product = lump.resource('Product')\nconst privateKey = 'xxxxxxxxxxxxxxxxxxxxxxxxx'\nasync function trySeal () {\n  await Product.seal(privateKey)\n}\ntrySeal()"
-          ],
-          "returns": {
-            "type": "Promise",
-            "description": ""
-          }
-        },
-        {
-          "name": "has",
-          "access": "",
-          "virtual": false,
-          "description": "Check entity with id exists",
-          "parameters": [
-            {
-              "name": "id",
-              "type": "ClayId",
-              "description": "Id of the entity",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [
-            "const Product = lump.resource('Product')\nasync function tryHas () {\n  let has = await Product.has(1)\n  console.log(has)\n}\ntryHas()"
-          ],
-          "returns": {
-            "type": "Promise.<boolean>",
-            "description": "Exists or not"
-          }
-        },
-        {
-          "name": "exists",
-          "access": "",
-          "virtual": false,
-          "description": "Check data exists with filter",
-          "parameters": [
-            {
-              "name": "filter",
-              "type": "FilterTerm",
-              "description": "List filter",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [
-            "const Product = lump.resource('Product')\nasync function tryExists () {\n  let exists = await Product.exists({ name: 'Super Super Orange' })\n  console.log(exists)\n}\ntryExists()"
-          ],
-          "returns": {
-            "type": "Promise.<boolean>",
-            "description": "Exists or not"
-          }
-        },
-        {
-          "name": "count",
-          "access": "",
-          "virtual": false,
-          "description": "Count data matches filter",
-          "parameters": [
-            {
-              "name": "filter",
-              "type": "FilterTerm",
-              "description": "List filter",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [
-            "const Product = lump.resource('Product')\nasync function tryCount () {\n  let count = await Product.count({ type: 'CAR' })\n  console.log(count)\n}\ntryCount()"
-          ],
-          "returns": {
-            "type": "Promise.<number>",
-            "description": "Number of entities"
-          }
-        },
-        {
-          "name": "of",
-          "access": "",
-          "virtual": false,
-          "description": "Find entity with attributes and returns if found.\nIf not found, create and return the one.",
-          "parameters": [
-            {
-              "name": "attributes",
-              "type": "Object",
-              "description": "Attributes",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [
-            "const Product = lump.resource('Product')\nasync function tryOf () {\n  let values = await Product.of({ code: '#1234' })\n  console.log(values)\n}\ntryOf()"
-          ]
-        },
-        {
-          "name": "all",
-          "access": "",
-          "virtual": false,
-          "description": "Get all entities inside resource which matches the filter",
-          "parameters": [
-            {
-              "name": "filter",
-              "type": "FilterTerm",
-              "description": "Listing filter",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            },
-            {
-              "name": "options",
-              "type": "Object",
-              "description": "Optional settings",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<Array.<ClayEntity>>",
-            "description": "Entities"
-          }
-        },
-        {
-          "name": "toggleAnnotate",
-          "access": "",
-          "virtual": false,
-          "description": "",
-          "parameters": [],
-          "examples": []
-        },
-        {
-          "name": "clone",
-          "access": "",
-          "virtual": false,
-          "description": "Clone the instance",
-          "parameters": [],
-          "examples": [],
-          "returns": {
-            "type": "Object",
-            "description": "Cloned instance"
-          }
-        },
-        {
-          "name": "addInbound",
-          "access": "",
-          "virtual": false,
-          "description": "Add inbound",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of inbound",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "inbound",
-              "type": "function",
-              "description": "Inbound function",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "InboundMixed",
-            "description": ""
-          }
-        },
-        {
-          "name": "hasInbound",
-          "access": "",
-          "virtual": false,
-          "description": "Check if has inbound",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of inbound",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "boolean",
-            "description": ""
-          }
-        },
-        {
-          "name": "removeInbound",
-          "access": "",
-          "virtual": false,
-          "description": "Remove inbound",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of inbound",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "InboundMixed",
-            "description": ""
-          }
-        },
-        {
-          "name": "applyInbound",
-          "access": "",
-          "virtual": false,
-          "description": "Apply inbound to array of attributes",
-          "parameters": [
-            {
-              "name": "attributesArray",
-              "type": "Array.<EntityAttributes>",
-              "description": "Array of attributes",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "ActionContext",
-              "description": "Context for resource action",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<Array.<EntityAttributes>>",
-            "description": "Inbounded attributes array"
-          }
-        },
-        {
-          "name": "inboundAttributes",
-          "access": "",
-          "virtual": false,
-          "description": "Inbound attributes",
-          "parameters": [
-            {
-              "name": "attributes",
-              "type": "EntityAttributes",
-              "description": "Attributes to inbound",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "ActionContext",
-              "description": "Context for resource action",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<EntityAttributes>",
-            "description": "Inbounded attributes"
-          }
-        },
-        {
-          "name": "inboundAttributesArray",
-          "access": "",
-          "virtual": false,
-          "description": "Inbound attributes array",
-          "parameters": [
-            {
-              "name": "attributesArray",
-              "type": "Array.<EntityAttributes>",
-              "description": "Attributes array to inbound",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "ActionContext",
-              "description": "Context for resource action",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<Array.<EntityAttributes>>",
-            "description": "Inbounded attributes array"
-          }
-        },
-        {
-          "name": "inboundAttributesHash",
-          "access": "",
-          "virtual": false,
-          "description": "Inbound attributes hash",
-          "parameters": [
-            {
-              "name": "attributesHash",
-              "type": "AttributesHash",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "ActionContext",
-              "description": "Context for resource action",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<AttributesHash>",
-            "description": ""
-          }
-        },
-        {
-          "name": "addOutbound",
-          "access": "",
-          "virtual": false,
-          "description": "Add outbound",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of outbound",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "handler",
-              "type": "function",
-              "description": "Format handler function",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "OutboundMixed",
-            "description": ""
-          }
-        },
-        {
-          "name": "hasOutbound",
-          "access": "",
-          "virtual": false,
-          "description": "Check if has outbound",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of outbound",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "boolean",
-            "description": ""
-          }
-        },
-        {
-          "name": "removeOutbound",
-          "access": "",
-          "virtual": false,
-          "description": "Remove outbound",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of outbound",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "OutboundMixed",
-            "description": ""
-          }
-        },
-        {
-          "name": "applyOutbound",
-          "access": "",
-          "virtual": false,
-          "description": "Apply outbound to entities",
-          "parameters": [
-            {
-              "name": "entities",
-              "type": "Array.<Entity>",
-              "description": "Entities to outbound",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "Object",
-              "description": "",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<Array.<Entity>>",
-            "description": "Formatted entities"
-          }
-        },
-        {
-          "name": "outboundEntity",
-          "access": "",
-          "virtual": false,
-          "description": "Format entity",
-          "parameters": [
-            {
-              "name": "entity",
-              "type": "Entity",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "Object",
-              "description": "",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<Entity>",
-            "description": ""
-          }
-        },
-        {
-          "name": "outboundEntityArray",
-          "access": "",
-          "virtual": false,
-          "description": "Proses entity array",
-          "parameters": [
-            {
-              "name": "entityArray",
-              "type": "Array.<Entity>",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "Object",
-              "description": "",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<Array.<Entity>>",
-            "description": ""
-          }
-        },
-        {
-          "name": "outboundCollection",
-          "access": "",
-          "virtual": false,
-          "description": "Format entity collection",
-          "parameters": [
-            {
-              "name": "collection",
-              "type": "Collection",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "Object",
-              "description": "",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<Collection>",
-            "description": ""
-          }
-        },
-        {
-          "name": "outboundEntityHash",
-          "access": "",
-          "virtual": false,
-          "description": "Format entity hash",
-          "parameters": [
-            {
-              "name": "entityHash",
-              "type": "EntityHash",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "Object",
-              "description": "",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<EntityHash>",
-            "description": ""
-          }
-        },
-        {
-          "name": "outboundCollectionArray",
-          "access": "",
-          "virtual": false,
-          "description": "Format collection array",
-          "parameters": [
-            {
-              "name": "collectionArray",
-              "type": "CollectionArray",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "Object",
-              "description": "",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<CollectionArray>",
-            "description": ""
-          }
-        },
-        {
-          "name": "getPolicy",
-          "access": "",
-          "virtual": false,
-          "description": "Get the policy",
-          "parameters": [],
-          "examples": [],
-          "returns": {
-            "type": "ClayPolicy",
-            "description": ""
-          }
-        },
-        {
-          "name": "setPolicy",
-          "access": "",
-          "virtual": false,
-          "description": "Set policy",
-          "parameters": [
-            {
-              "name": "policy",
-              "type": "",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "PolicyMix",
-            "description": "this"
-          }
-        },
-        {
-          "name": "removePolicy",
-          "access": "",
-          "virtual": false,
-          "description": "Remove policy",
-          "parameters": [],
-          "examples": []
-        },
-        {
-          "name": "fetchPolicy",
-          "access": "",
-          "virtual": false,
-          "description": "Fetch policy from db",
-          "parameters": [
-            {
-              "name": "digest",
-              "type": "string",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<ClayPolicy>",
-            "description": ""
-          }
-        },
-        {
-          "name": "savePolicy",
-          "access": "",
-          "virtual": false,
-          "description": "Save policy",
-          "parameters": [
-            {
-              "name": "policy",
-              "type": "ClayPolicy",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<string>",
-            "description": "Digest of saved policy"
-          }
-        },
-        {
-          "name": "addRef",
-          "access": "",
-          "virtual": false,
-          "description": "Add resource ref",
-          "parameters": [
-            {
-              "name": "resourceName",
-              "type": "string",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "resource",
-              "type": "ClayResource",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": []
-        },
-        {
-          "name": "hasRef",
-          "access": "",
-          "virtual": false,
-          "description": "has resources ref",
-          "parameters": [
-            {
-              "name": "resourceName",
-              "type": "string",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "boolean",
-            "description": ""
-          }
-        },
-        {
-          "name": "removeRef",
-          "access": "",
-          "virtual": false,
-          "description": "Remove resource ref",
-          "parameters": [
-            {
-              "name": "resourceName",
-              "type": "string",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "FormatMix",
-            "description": ""
-          }
-        },
-        {
-          "name": "sub",
-          "access": "",
-          "virtual": false,
-          "description": "Get sub resource",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "ClayResource",
-            "description": ""
-          }
-        },
-        {
-          "name": "subNames",
-          "access": "",
-          "virtual": false,
-          "description": "Get names of sub resources",
-          "parameters": [],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<Array.<string>>",
-            "description": ""
-          }
-        },
-        {
-          "name": "throwEntityNotFoundError",
-          "access": "",
-          "virtual": false,
-          "description": "Throw entity not found error",
-          "parameters": [
-            {
-              "name": "id",
-              "type": "ClayId",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": []
-        },
-        {
-          "name": "internal",
-          "access": "",
-          "virtual": false,
-          "description": "Get internal resource",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "ClayResource",
-            "description": ""
-          }
-        },
-        {
-          "name": "internalNames",
-          "access": "",
-          "virtual": false,
-          "description": "Get names of internal resources",
-          "parameters": [],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<Array.<string>>",
-            "description": ""
-          }
-        },
-        {
-          "name": "prepareIfNeeded",
-          "access": "",
-          "virtual": false,
-          "description": "Do prepare if needed",
-          "parameters": [],
-          "examples": [],
-          "returns": {
-            "type": "Promise",
-            "description": ""
-          }
-        },
-        {
-          "name": "prepare",
-          "access": "",
-          "virtual": false,
-          "description": "Do preparing",
-          "parameters": [],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<Object>",
-            "description": ""
-          }
-        },
-        {
-          "name": "addPrepareTask",
-          "access": "",
-          "virtual": false,
-          "description": "Add prepare task",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of task",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "task",
-              "type": "function",
-              "description": "Task function",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "PrepareMixed",
-            "description": "Returns this"
-          }
-        },
-        {
-          "name": "hasPrepareTask",
-          "access": "",
-          "virtual": false,
-          "description": "Check if has task",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "boolean",
-            "description": "Has or not"
-          }
-        },
-        {
-          "name": "removePrepareTask",
-          "access": "",
-          "virtual": false,
-          "description": "Remove a task",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of task",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "PrepareMixed",
-            "description": ""
-          }
-        },
-        {
-          "name": "setNeedsPrepare",
-          "access": "",
-          "virtual": false,
-          "description": "Set needs prepare",
-          "parameters": [
-            {
-              "name": "needsPrepare",
-              "type": "boolean",
-              "description": "Needs preparing",
-              "default": true,
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "PrepareMixed",
-            "description": "Returns self"
-          }
-        },
-        {
-          "name": "decorate",
-          "access": "",
-          "virtual": false,
-          "description": "Decorate a method",
-          "parameters": [
-            {
-              "name": "methodName",
-              "type": "string",
-              "description": "Name of method",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "decorate",
-              "type": "function",
-              "description": "Decorate function",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "DecorateMixed",
-            "description": "Returns this"
-          }
-        },
-        {
-          "name": "caches",
-          "access": "",
-          "virtual": false,
-          "description": "Toggle caching",
-          "parameters": [
-            {
-              "name": "caches",
-              "type": "boolean",
-              "description": "Should cache or not",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "CacheMixed",
-            "description": "this"
-          }
-        },
-        {
-          "name": "storeCache",
-          "access": "",
-          "virtual": false,
-          "description": "Store an entity into cache",
-          "parameters": [
-            {
-              "name": "entity",
-              "type": "",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": []
-        },
-        {
-          "name": "gainCache",
-          "access": "",
-          "virtual": false,
-          "description": "Gain entity from cache",
-          "parameters": [
-            {
-              "name": "id",
-              "type": "ClayId",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": []
-        },
-        {
-          "name": "requestCacheClear",
-          "access": "",
-          "virtual": false,
-          "description": "Request cache clear",
-          "parameters": [
-            {
-              "name": "ids",
-              "type": [
-                "ClayId",
-                "Array.<ClayId>"
-              ],
-              "description": "Ids to clear",
-              "default": "",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": []
-        },
-        {
-          "name": "parseCondition",
-          "access": "",
-          "virtual": false,
-          "description": "Parse list condition",
-          "parameters": [
-            {
-              "name": "condition",
-              "type": "ListCondition",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "ListCondition",
-            "description": "- Parsed condition"
-          }
-        },
-        {
-          "name": "parseConditionArray",
-          "access": "",
-          "virtual": false,
-          "description": "Parse list condition array",
-          "parameters": [
-            {
-              "name": "conditionArray",
-              "type": "Array.<ListCondition>",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Array.<ListCondition>",
-            "description": "- Parsed condition array"
-          }
+            "functions": [
+                {
+                    "name": "throwEntityNotFoundError",
+                    "access": "",
+                    "virtual": false,
+                    "description": "Throw entity not found error",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "type": "ClayId",
+                            "description": "",
+                            "default": "",
+                            "optional": "",
+                            "nullable": ""
+                        }
+                    ],
+                    "examples": []
+                }
+            ]
         }
-      ]
-    },
-    {
-      "name": "AnnotateMixed",
-      "description": "",
-      "extends": [],
-      "access": "",
-      "virtual": false,
-      "fires": "",
-      "constructor": {
-        "name": "AnnotateMixed",
-        "description": "",
-        "parameters": [],
-        "examples": []
-      },
-      "functions": [
+    ],
+    "functions": [
         {
-          "name": "toggleAnnotate",
-          "access": "",
-          "virtual": false,
-          "description": "",
-          "parameters": [],
-          "examples": []
+            "name": "fromDriver",
+            "access": "",
+            "virtual": false,
+            "description": "",
+            "parameters": [
+                {
+                    "name": "driver",
+                    "type": "Driver",
+                    "description": "Driver to bind",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                },
+                {
+                    "name": "nameString",
+                    "type": "string",
+                    "description": "Resource name string",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                },
+                {
+                    "name": "options",
+                    "type": "Object",
+                    "description": "Optional settings",
+                    "default": "{}",
+                    "optional": true,
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "ClayResource",
+                "description": "Resource instance"
+            }
+        },
+        {
+            "name": "create",
+            "access": "",
+            "virtual": false,
+            "description": "Create a ClayResource instance",
+            "parameters": [
+                {
+                    "name": "args",
+                    "type": "*",
+                    "description": "",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "ClayResource",
+                "description": ""
+            }
+        },
+        {
+            "name": "fromDriver",
+            "access": "",
+            "virtual": false,
+            "description": "Create clayResource class from driver",
+            "parameters": [
+                {
+                    "name": "driver",
+                    "type": "Driver",
+                    "description": "Driver to bind",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                },
+                {
+                    "name": "nameString",
+                    "type": "string",
+                    "description": "Resource name string",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                },
+                {
+                    "name": "options",
+                    "type": "Object",
+                    "description": "Optional settings",
+                    "default": "{}",
+                    "optional": true,
+                    "nullable": ""
+                }
+            ],
+            "examples": [
+                "const { fromDriver } = require('clay-resource')\nconst { SqliteDriver } = require('clay-driver-sqlite')\n{\n  let driver = new SqliteDriver('var/test.db')\n  let resource = fromDriver(driver)\n}"
+            ],
+            "returns": {
+                "type": "ClayResource",
+                "description": "Resource instance"
+            }
+        },
+        {
+            "name": "fromDriver",
+            "access": "",
+            "virtual": false,
+            "description": "",
+            "parameters": [
+                {
+                    "name": "driver",
+                    "type": "Driver",
+                    "description": "Driver to bind",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                },
+                {
+                    "name": "nameString",
+                    "type": "string",
+                    "description": "Resource name string",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                },
+                {
+                    "name": "options",
+                    "type": "Object",
+                    "description": "Optional settings",
+                    "default": "{}",
+                    "optional": true,
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "ClayResource",
+                "description": "Resource instance"
+            }
+        },
+        {
+            "name": "create",
+            "access": "",
+            "virtual": false,
+            "description": "Create a ClayResource instance",
+            "parameters": [
+                {
+                    "name": "args",
+                    "type": "*",
+                    "description": "",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "ClayResource",
+                "description": ""
+            }
+        },
+        {
+            "name": "fromDriver",
+            "access": "",
+            "virtual": false,
+            "description": "Create clayResource class from driver",
+            "parameters": [
+                {
+                    "name": "driver",
+                    "type": "Driver",
+                    "description": "Driver to bind",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                },
+                {
+                    "name": "nameString",
+                    "type": "string",
+                    "description": "Resource name string",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                },
+                {
+                    "name": "options",
+                    "type": "Object",
+                    "description": "Optional settings",
+                    "default": "{}",
+                    "optional": true,
+                    "nullable": ""
+                }
+            ],
+            "examples": [
+                "const { fromDriver } = require('clay-resource')\nconst { SqliteDriver } = require('clay-driver-sqlite')\n{\n  let driver = new SqliteDriver('var/test.db')\n  let resource = fromDriver(driver)\n}"
+            ],
+            "returns": {
+                "type": "ClayResource",
+                "description": "Resource instance"
+            }
+        },
+        {
+            "name": "asEntity",
+            "access": "",
+            "virtual": false,
+            "description": "Convert as entity",
+            "parameters": [
+                {
+                    "name": "attributes",
+                    "type": "Object",
+                    "description": "Entity attributes",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "Object",
+                "description": "entity"
+            }
+        },
+        {
+            "name": "sureId",
+            "access": "",
+            "virtual": false,
+            "description": "Make sure that given object is an id",
+            "parameters": [
+                {
+                    "name": "id",
+                    "type": "*",
+                    "description": "",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                },
+                {
+                    "name": "options",
+                    "type": "Object",
+                    "description": "Optional settings",
+                    "default": "{}",
+                    "optional": true,
+                    "nullable": ""
+                },
+                {
+                    "name": "options.prefix",
+                    "type": "string",
+                    "description": "Prefix for errors",
+                    "default": "",
+                    "optional": true,
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": [
+                    "ClayId",
+                    "String"
+                ],
+                "description": "id"
+            }
+        },
+        {
+            "name": "policyInbound",
+            "access": "",
+            "virtual": false,
+            "description": "Define inbound function for policy",
+            "parameters": [
+                {
+                    "name": "policy",
+                    "type": "ClayPolicy",
+                    "description": "Policy to bind",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                },
+                {
+                    "name": "resource",
+                    "type": "ClayResource",
+                    "description": "Resource of entities",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "function",
+                "description": "Inbound function"
+            }
+        },
+        {
+            "name": "refInbound",
+            "access": "",
+            "virtual": false,
+            "description": "Define inbound function for resource",
+            "parameters": [
+                {
+                    "name": "refResource",
+                    "type": "ClayResource",
+                    "description": "Resource of entities",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "function",
+                "description": "Inbound function"
+            }
+        },
+        {
+            "name": "annotateMix",
+            "access": "",
+            "virtual": false,
+            "description": "Mixin for annotate feature",
+            "parameters": [
+                {
+                    "name": "BaseClass",
+                    "type": "function",
+                    "description": "Class to mix",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "function",
+                "description": "Mixed class"
+            }
+        },
+        {
+            "name": "annotates",
+            "access": "",
+            "virtual": false,
+            "description": "Toggle annotate support",
+            "parameters": [
+                {
+                    "name": "annotates",
+                    "type": "boolean",
+                    "description": "Should annotate or not",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "AnnotateMixed",
+                "description": "this"
+            }
+        },
+        {
+            "name": "cacheMix",
+            "access": "",
+            "virtual": false,
+            "description": "Mixin for cache",
+            "parameters": [
+                {
+                    "name": "BaseClass",
+                    "type": "function",
+                    "description": "Class to mix",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "function",
+                "description": "Mixed class"
+            }
+        },
+        {
+            "name": "cloneMix",
+            "access": "",
+            "virtual": false,
+            "description": "Mixin for clone feature",
+            "parameters": [
+                {
+                    "name": "BaseClass",
+                    "type": "function",
+                    "description": "Class to mix",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "function",
+                "description": "Mixed class"
+            }
+        },
+        {
+            "name": "collectionMix",
+            "access": "",
+            "virtual": false,
+            "description": "Mixin for collection",
+            "parameters": [
+                {
+                    "name": "BaseClass",
+                    "type": "function",
+                    "description": "Class to mix",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "function",
+                "description": "Mixed class"
+            }
+        },
+        {
+            "name": "conditionMix",
+            "access": "",
+            "virtual": false,
+            "description": "Mixin for condition",
+            "parameters": [
+                {
+                    "name": "BaseClass",
+                    "type": "function",
+                    "description": "Class to mix",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "function",
+                "description": "Mixed class"
+            }
+        },
+        {
+            "name": "decorateMix",
+            "access": "private",
+            "virtual": false,
+            "description": "Mix decorate support",
+            "parameters": [
+                {
+                    "name": "BaseClass",
+                    "type": "function",
+                    "description": "Class to mix",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "function",
+                "description": "Mixed class"
+            }
+        },
+        {
+            "name": "entityMix",
+            "access": "",
+            "virtual": false,
+            "description": "Mixin for entity",
+            "parameters": [
+                {
+                    "name": "BaseClass",
+                    "type": "function",
+                    "description": "Class to mix",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "function",
+                "description": "Mixed class"
+            }
+        },
+        {
+            "name": "inboundMix",
+            "access": "",
+            "virtual": false,
+            "description": "Mixin for inbound feature. Convert in-bind data like attributes to create/update",
+            "parameters": [
+                {
+                    "name": "BaseClass",
+                    "type": "function",
+                    "description": "Class to mix",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "function",
+                "description": "Mixed class"
+            }
+        },
+        {
+            "name": "internalMix",
+            "access": "",
+            "virtual": false,
+            "description": "Mixin for internal feature",
+            "parameters": [
+                {
+                    "name": "BaseClass",
+                    "type": "function",
+                    "description": "Class to mix",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "function",
+                "description": "Mixed class"
+            }
+        },
+        {
+            "name": "outboundMix",
+            "access": "",
+            "virtual": false,
+            "description": "Mixin for outbound feature. Convert out-bind data like entity, collection",
+            "parameters": [
+                {
+                    "name": "BaseClass",
+                    "type": "function",
+                    "description": "Class to mix",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "function",
+                "description": "Mixed class"
+            }
+        },
+        {
+            "name": "policyMix",
+            "access": "",
+            "virtual": false,
+            "description": "Mixin for policy feature",
+            "parameters": [
+                {
+                    "name": "BaseClass",
+                    "type": "function",
+                    "description": "Class to mix",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "function",
+                "description": "Mixed class"
+            }
+        },
+        {
+            "name": "prepareMix",
+            "access": "",
+            "virtual": false,
+            "description": "Mixin for prepare feature",
+            "parameters": [
+                {
+                    "name": "BaseClass",
+                    "type": "function",
+                    "description": "Class to mix",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "function",
+                "description": "Mixed class"
+            }
+        },
+        {
+            "name": "refMix",
+            "access": "",
+            "virtual": false,
+            "description": "Mixin for ref feature",
+            "parameters": [
+                {
+                    "name": "BaseClass",
+                    "type": "function",
+                    "description": "Class to mix",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "function",
+                "description": "Mixed class"
+            }
+        },
+        {
+            "name": "subMix",
+            "access": "",
+            "virtual": false,
+            "description": "Mixin for sub feature",
+            "parameters": [
+                {
+                    "name": "BaseClass",
+                    "type": "function",
+                    "description": "Class to mix",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "function",
+                "description": "Mixed class"
+            }
+        },
+        {
+            "name": "throwMix",
+            "access": "",
+            "virtual": false,
+            "description": "Mixin for throw feature.",
+            "parameters": [
+                {
+                    "name": "BaseClass",
+                    "type": "function",
+                    "description": "Class to mix",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "function",
+                "description": "Mixed class"
+            }
+        },
+        {
+            "name": "annotationOutbound",
+            "access": "",
+            "virtual": false,
+            "description": "Define outbound to strip entity annotations.",
+            "parameters": [],
+            "examples": [],
+            "returns": {
+                "type": "function",
+                "description": "Outbound function"
+            }
+        },
+        {
+            "name": "annotationOutbound",
+            "access": "",
+            "virtual": false,
+            "description": "",
+            "parameters": [
+                {
+                    "name": null,
+                    "type": "Array.<Entity>",
+                    "description": "Entities",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "Promise.<Array.<Entity>>",
+                "description": ""
+            }
+        },
+        {
+            "name": "refOutbound",
+            "access": "",
+            "virtual": false,
+            "description": "Define outbound to load entity refs",
+            "parameters": [
+                {
+                    "name": "refResource",
+                    "type": "ClayResource",
+                    "description": "Resource of entities",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "function",
+                "description": "Outbound function"
+            }
+        },
+        {
+            "name": "refOutbound",
+            "access": "",
+            "virtual": false,
+            "description": "",
+            "parameters": [
+                {
+                    "name": null,
+                    "type": "Array.<Entity>",
+                    "description": "Entities",
+                    "default": "",
+                    "optional": "",
+                    "nullable": ""
+                },
+                {
+                    "name": "actionContext",
+                    "type": "Object",
+                    "description": "",
+                    "default": "{}",
+                    "optional": true,
+                    "nullable": ""
+                }
+            ],
+            "examples": [],
+            "returns": {
+                "type": "Promise.<Array.<Entity>>",
+                "description": ""
+            }
         }
-      ]
-    },
-    {
-      "name": "CacheMixed",
-      "description": "",
-      "extends": [],
-      "access": "",
-      "virtual": false,
-      "fires": "",
-      "constructor": {
-        "name": "CacheMixed",
-        "description": "",
-        "parameters": [],
-        "examples": []
-      },
-      "functions": [
-        {
-          "name": "caches",
-          "access": "",
-          "virtual": false,
-          "description": "Toggle caching",
-          "parameters": [
-            {
-              "name": "caches",
-              "type": "boolean",
-              "description": "Should cache or not",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "CacheMixed",
-            "description": "this"
-          }
-        },
-        {
-          "name": "storeCache",
-          "access": "",
-          "virtual": false,
-          "description": "Store an entity into cache",
-          "parameters": [
-            {
-              "name": "entity",
-              "type": "",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": []
-        },
-        {
-          "name": "gainCache",
-          "access": "",
-          "virtual": false,
-          "description": "Gain entity from cache",
-          "parameters": [
-            {
-              "name": "id",
-              "type": "ClayId",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": []
-        },
-        {
-          "name": "requestCacheClear",
-          "access": "",
-          "virtual": false,
-          "description": "Request cache clear",
-          "parameters": [
-            {
-              "name": "ids",
-              "type": [
-                "ClayId",
-                "Array.<ClayId>"
-              ],
-              "description": "Ids to clear",
-              "default": "",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": []
-        }
-      ]
-    },
-    {
-      "name": "CloneMixed",
-      "description": "",
-      "extends": [],
-      "access": "",
-      "virtual": false,
-      "fires": "",
-      "constructor": {
-        "name": "CloneMixed",
-        "description": "",
-        "parameters": [],
-        "examples": []
-      },
-      "functions": [
-        {
-          "name": "clone",
-          "access": "",
-          "virtual": false,
-          "description": "Clone the instance",
-          "parameters": [],
-          "examples": [],
-          "returns": {
-            "type": "Object",
-            "description": "Cloned instance"
-          }
-        }
-      ]
-    },
-    {
-      "name": "CollectionMixed",
-      "description": "",
-      "extends": [],
-      "access": "",
-      "virtual": false,
-      "fires": "",
-      "constructor": {
-        "name": "CollectionMixed",
-        "description": "",
-        "parameters": [],
-        "examples": []
-      },
-      "functions": [
-        {
-          "name": "createResourceCollection",
-          "access": "",
-          "virtual": false,
-          "description": "Convert collection into resource collection",
-          "parameters": [
-            {
-              "name": "collection",
-              "type": "Collection",
-              "description": "Collection to convert",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "CollectionMixed.ResourceCollection",
-            "description": ""
-          }
-        },
-        {
-          "name": "enhanceResourceCollection",
-          "access": "",
-          "virtual": false,
-          "description": "Extend resource collection",
-          "parameters": [
-            {
-              "name": "enhancer",
-              "type": "function",
-              "description": "Enhancer function",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "EntityMixed",
-            "description": "Returns this for chaining"
-          }
-        }
-      ]
-    },
-    {
-      "name": "ConditionMixed",
-      "description": "",
-      "extends": [],
-      "access": "",
-      "virtual": false,
-      "fires": "",
-      "constructor": {
-        "name": "ConditionMixed",
-        "description": "",
-        "parameters": [],
-        "examples": []
-      },
-      "functions": [
-        {
-          "name": "parseCondition",
-          "access": "",
-          "virtual": false,
-          "description": "Parse list condition",
-          "parameters": [
-            {
-              "name": "condition",
-              "type": "ListCondition",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "ListCondition",
-            "description": "- Parsed condition"
-          }
-        },
-        {
-          "name": "parseConditionArray",
-          "access": "",
-          "virtual": false,
-          "description": "Parse list condition array",
-          "parameters": [
-            {
-              "name": "conditionArray",
-              "type": "Array.<ListCondition>",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Array.<ListCondition>",
-            "description": "- Parsed condition array"
-          }
-        }
-      ]
-    },
-    {
-      "name": "DecorateMixed",
-      "description": "",
-      "extends": [],
-      "access": "",
-      "virtual": false,
-      "fires": "",
-      "constructor": {
-        "name": "DecorateMixed",
-        "description": "",
-        "parameters": [],
-        "examples": []
-      },
-      "functions": [
-        {
-          "name": "decorate",
-          "access": "",
-          "virtual": false,
-          "description": "Decorate a method",
-          "parameters": [
-            {
-              "name": "methodName",
-              "type": "string",
-              "description": "Name of method",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "decorate",
-              "type": "function",
-              "description": "Decorate function",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "DecorateMixed",
-            "description": "Returns this"
-          }
-        }
-      ]
-    },
-    {
-      "name": "EntityMixed",
-      "description": "",
-      "extends": [],
-      "access": "",
-      "virtual": false,
-      "fires": "",
-      "constructor": {
-        "name": "EntityMixed",
-        "description": "",
-        "parameters": [],
-        "examples": []
-      },
-      "functions": [
-        {
-          "name": "createResourceEntity",
-          "access": "",
-          "virtual": false,
-          "description": "Convert entity into resource entity",
-          "parameters": [
-            {
-              "name": "entity",
-              "type": "Entity",
-              "description": "to convert",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "EntityMixed.ResourceEntity",
-            "description": ""
-          }
-        },
-        {
-          "name": "enhanceResourceEntity",
-          "access": "",
-          "virtual": false,
-          "description": "Extend resource entity",
-          "parameters": [
-            {
-              "name": "enhancer",
-              "type": "function",
-              "description": "Enhancer function",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "EntityMixed",
-            "description": "Returns this for chaining"
-          }
-        }
-      ]
-    },
-    {
-      "name": "InboundMixed",
-      "description": "",
-      "extends": [],
-      "access": "",
-      "virtual": false,
-      "fires": "",
-      "constructor": {
-        "name": "InboundMixed",
-        "description": "",
-        "parameters": [],
-        "examples": []
-      },
-      "functions": [
-        {
-          "name": "addInbound",
-          "access": "",
-          "virtual": false,
-          "description": "Add inbound",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of inbound",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "inbound",
-              "type": "function",
-              "description": "Inbound function",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "InboundMixed",
-            "description": ""
-          }
-        },
-        {
-          "name": "hasInbound",
-          "access": "",
-          "virtual": false,
-          "description": "Check if has inbound",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of inbound",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "boolean",
-            "description": ""
-          }
-        },
-        {
-          "name": "removeInbound",
-          "access": "",
-          "virtual": false,
-          "description": "Remove inbound",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of inbound",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "InboundMixed",
-            "description": ""
-          }
-        },
-        {
-          "name": "applyInbound",
-          "access": "",
-          "virtual": false,
-          "description": "Apply inbound to array of attributes",
-          "parameters": [
-            {
-              "name": "attributesArray",
-              "type": "Array.<EntityAttributes>",
-              "description": "Array of attributes",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "ActionContext",
-              "description": "Context for resource action",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<Array.<EntityAttributes>>",
-            "description": "Inbounded attributes array"
-          }
-        },
-        {
-          "name": "inboundAttributes",
-          "access": "",
-          "virtual": false,
-          "description": "Inbound attributes",
-          "parameters": [
-            {
-              "name": "attributes",
-              "type": "EntityAttributes",
-              "description": "Attributes to inbound",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "ActionContext",
-              "description": "Context for resource action",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<EntityAttributes>",
-            "description": "Inbounded attributes"
-          }
-        },
-        {
-          "name": "inboundAttributesArray",
-          "access": "",
-          "virtual": false,
-          "description": "Inbound attributes array",
-          "parameters": [
-            {
-              "name": "attributesArray",
-              "type": "Array.<EntityAttributes>",
-              "description": "Attributes array to inbound",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "ActionContext",
-              "description": "Context for resource action",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<Array.<EntityAttributes>>",
-            "description": "Inbounded attributes array"
-          }
-        },
-        {
-          "name": "inboundAttributesHash",
-          "access": "",
-          "virtual": false,
-          "description": "Inbound attributes hash",
-          "parameters": [
-            {
-              "name": "attributesHash",
-              "type": "AttributesHash",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "ActionContext",
-              "description": "Context for resource action",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<AttributesHash>",
-            "description": ""
-          }
-        }
-      ]
-    },
-    {
-      "name": "InternalMixed",
-      "description": "",
-      "extends": [],
-      "access": "",
-      "virtual": false,
-      "fires": "",
-      "constructor": {
-        "name": "InternalMixed",
-        "description": "",
-        "parameters": [],
-        "examples": []
-      },
-      "functions": [
-        {
-          "name": "internal",
-          "access": "",
-          "virtual": false,
-          "description": "Get internal resource",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "ClayResource",
-            "description": ""
-          }
-        },
-        {
-          "name": "internalNames",
-          "access": "",
-          "virtual": false,
-          "description": "Get names of internal resources",
-          "parameters": [],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<Array.<string>>",
-            "description": ""
-          }
-        }
-      ]
-    },
-    {
-      "name": "OutboundMixed",
-      "description": "",
-      "extends": [],
-      "access": "",
-      "virtual": false,
-      "fires": "",
-      "constructor": {
-        "name": "OutboundMixed",
-        "description": "",
-        "parameters": [],
-        "examples": []
-      },
-      "functions": [
-        {
-          "name": "addOutbound",
-          "access": "",
-          "virtual": false,
-          "description": "Add outbound",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of outbound",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "handler",
-              "type": "function",
-              "description": "Format handler function",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "OutboundMixed",
-            "description": ""
-          }
-        },
-        {
-          "name": "hasOutbound",
-          "access": "",
-          "virtual": false,
-          "description": "Check if has outbound",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of outbound",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "boolean",
-            "description": ""
-          }
-        },
-        {
-          "name": "removeOutbound",
-          "access": "",
-          "virtual": false,
-          "description": "Remove outbound",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of outbound",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "OutboundMixed",
-            "description": ""
-          }
-        },
-        {
-          "name": "applyOutbound",
-          "access": "",
-          "virtual": false,
-          "description": "Apply outbound to entities",
-          "parameters": [
-            {
-              "name": "entities",
-              "type": "Array.<Entity>",
-              "description": "Entities to outbound",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "Object",
-              "description": "",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<Array.<Entity>>",
-            "description": "Formatted entities"
-          }
-        },
-        {
-          "name": "outboundEntity",
-          "access": "",
-          "virtual": false,
-          "description": "Format entity",
-          "parameters": [
-            {
-              "name": "entity",
-              "type": "Entity",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "Object",
-              "description": "",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<Entity>",
-            "description": ""
-          }
-        },
-        {
-          "name": "outboundEntityArray",
-          "access": "",
-          "virtual": false,
-          "description": "Proses entity array",
-          "parameters": [
-            {
-              "name": "entityArray",
-              "type": "Array.<Entity>",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "Object",
-              "description": "",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<Array.<Entity>>",
-            "description": ""
-          }
-        },
-        {
-          "name": "outboundCollection",
-          "access": "",
-          "virtual": false,
-          "description": "Format entity collection",
-          "parameters": [
-            {
-              "name": "collection",
-              "type": "Collection",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "Object",
-              "description": "",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<Collection>",
-            "description": ""
-          }
-        },
-        {
-          "name": "outboundEntityHash",
-          "access": "",
-          "virtual": false,
-          "description": "Format entity hash",
-          "parameters": [
-            {
-              "name": "entityHash",
-              "type": "EntityHash",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "Object",
-              "description": "",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<EntityHash>",
-            "description": ""
-          }
-        },
-        {
-          "name": "outboundCollectionArray",
-          "access": "",
-          "virtual": false,
-          "description": "Format collection array",
-          "parameters": [
-            {
-              "name": "collectionArray",
-              "type": "CollectionArray",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "actionContext",
-              "type": "Object",
-              "description": "",
-              "default": "{}",
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<CollectionArray>",
-            "description": ""
-          }
-        }
-      ]
-    },
-    {
-      "name": "PolicyMixed",
-      "description": "",
-      "extends": [],
-      "access": "",
-      "virtual": false,
-      "fires": "",
-      "constructor": {
-        "name": "PolicyMixed",
-        "description": "",
-        "parameters": [],
-        "examples": []
-      },
-      "functions": [
-        {
-          "name": "getPolicy",
-          "access": "",
-          "virtual": false,
-          "description": "Get the policy",
-          "parameters": [],
-          "examples": [],
-          "returns": {
-            "type": "ClayPolicy",
-            "description": ""
-          }
-        },
-        {
-          "name": "setPolicy",
-          "access": "",
-          "virtual": false,
-          "description": "Set policy",
-          "parameters": [
-            {
-              "name": "policy",
-              "type": "",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "PolicyMix",
-            "description": "this"
-          }
-        },
-        {
-          "name": "removePolicy",
-          "access": "",
-          "virtual": false,
-          "description": "Remove policy",
-          "parameters": [],
-          "examples": []
-        },
-        {
-          "name": "fetchPolicy",
-          "access": "",
-          "virtual": false,
-          "description": "Fetch policy from db",
-          "parameters": [
-            {
-              "name": "digest",
-              "type": "string",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<ClayPolicy>",
-            "description": ""
-          }
-        },
-        {
-          "name": "savePolicy",
-          "access": "",
-          "virtual": false,
-          "description": "Save policy",
-          "parameters": [
-            {
-              "name": "policy",
-              "type": "ClayPolicy",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<string>",
-            "description": "Digest of saved policy"
-          }
-        }
-      ]
-    },
-    {
-      "name": "PrepareMixed",
-      "description": "",
-      "extends": [],
-      "access": "",
-      "virtual": false,
-      "fires": "",
-      "constructor": {
-        "name": "PrepareMixed",
-        "description": "",
-        "parameters": [],
-        "examples": []
-      },
-      "functions": [
-        {
-          "name": "prepareIfNeeded",
-          "access": "",
-          "virtual": false,
-          "description": "Do prepare if needed",
-          "parameters": [],
-          "examples": [],
-          "returns": {
-            "type": "Promise",
-            "description": ""
-          }
-        },
-        {
-          "name": "prepare",
-          "access": "",
-          "virtual": false,
-          "description": "Do preparing",
-          "parameters": [],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<Object>",
-            "description": ""
-          }
-        },
-        {
-          "name": "addPrepareTask",
-          "access": "",
-          "virtual": false,
-          "description": "Add prepare task",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of task",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "task",
-              "type": "function",
-              "description": "Task function",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "PrepareMixed",
-            "description": "Returns this"
-          }
-        },
-        {
-          "name": "hasPrepareTask",
-          "access": "",
-          "virtual": false,
-          "description": "Check if has task",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "boolean",
-            "description": "Has or not"
-          }
-        },
-        {
-          "name": "removePrepareTask",
-          "access": "",
-          "virtual": false,
-          "description": "Remove a task",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of task",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "PrepareMixed",
-            "description": ""
-          }
-        },
-        {
-          "name": "setNeedsPrepare",
-          "access": "",
-          "virtual": false,
-          "description": "Set needs prepare",
-          "parameters": [
-            {
-              "name": "needsPrepare",
-              "type": "boolean",
-              "description": "Needs preparing",
-              "default": true,
-              "optional": true,
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "PrepareMixed",
-            "description": "Returns self"
-          }
-        }
-      ]
-    },
-    {
-      "name": "RefMixed",
-      "description": "",
-      "extends": [],
-      "access": "",
-      "virtual": false,
-      "fires": "",
-      "constructor": {
-        "name": "RefMixed",
-        "description": "",
-        "parameters": [],
-        "examples": []
-      },
-      "functions": [
-        {
-          "name": "addRef",
-          "access": "",
-          "virtual": false,
-          "description": "Add resource ref",
-          "parameters": [
-            {
-              "name": "resourceName",
-              "type": "string",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            },
-            {
-              "name": "resource",
-              "type": "ClayResource",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": []
-        },
-        {
-          "name": "hasRef",
-          "access": "",
-          "virtual": false,
-          "description": "has resources ref",
-          "parameters": [
-            {
-              "name": "resourceName",
-              "type": "string",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "boolean",
-            "description": ""
-          }
-        },
-        {
-          "name": "removeRef",
-          "access": "",
-          "virtual": false,
-          "description": "Remove resource ref",
-          "parameters": [
-            {
-              "name": "resourceName",
-              "type": "string",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "FormatMix",
-            "description": ""
-          }
-        }
-      ]
-    },
-    {
-      "name": "SubMixed",
-      "description": "",
-      "extends": [],
-      "access": "",
-      "virtual": false,
-      "fires": "",
-      "constructor": {
-        "name": "SubMixed",
-        "description": "",
-        "parameters": [],
-        "examples": []
-      },
-      "functions": [
-        {
-          "name": "sub",
-          "access": "",
-          "virtual": false,
-          "description": "Get sub resource",
-          "parameters": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": [],
-          "returns": {
-            "type": "ClayResource",
-            "description": ""
-          }
-        },
-        {
-          "name": "subNames",
-          "access": "",
-          "virtual": false,
-          "description": "Get names of sub resources",
-          "parameters": [],
-          "examples": [],
-          "returns": {
-            "type": "Promise.<Array.<string>>",
-            "description": ""
-          }
-        }
-      ]
-    },
-    {
-      "name": "ThrowMixed",
-      "description": "",
-      "extends": [],
-      "access": "",
-      "virtual": false,
-      "fires": "",
-      "constructor": {
-        "name": "ThrowMixed",
-        "description": "",
-        "parameters": [],
-        "examples": []
-      },
-      "functions": [
-        {
-          "name": "throwEntityNotFoundError",
-          "access": "",
-          "virtual": false,
-          "description": "Throw entity not found error",
-          "parameters": [
-            {
-              "name": "id",
-              "type": "ClayId",
-              "description": "",
-              "default": "",
-              "optional": "",
-              "nullable": ""
-            }
-          ],
-          "examples": []
-        }
-      ]
-    }
-  ],
-  "functions": [
-    {
-      "name": "fromDriver",
-      "access": "",
-      "virtual": false,
-      "description": "",
-      "parameters": [
-        {
-          "name": "driver",
-          "type": "Driver",
-          "description": "Driver to bind",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        },
-        {
-          "name": "nameString",
-          "type": "string",
-          "description": "Resource name string",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        },
-        {
-          "name": "options",
-          "type": "Object",
-          "description": "Optional settings",
-          "default": "{}",
-          "optional": true,
-          "nullable": ""
-        }
-      ],
-      "examples": [],
-      "returns": {
-        "type": "ClayResource",
-        "description": "Resource instance"
-      }
-    },
-    {
-      "name": "create",
-      "access": "",
-      "virtual": false,
-      "description": "Create a ClayResource instance",
-      "parameters": [
-        {
-          "name": "args",
-          "type": "*",
-          "description": "",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        }
-      ],
-      "examples": [],
-      "returns": {
-        "type": "ClayResource",
-        "description": ""
-      }
-    },
-    {
-      "name": "fromDriver",
-      "access": "",
-      "virtual": false,
-      "description": "Create clayResource class from driver",
-      "parameters": [
-        {
-          "name": "driver",
-          "type": "Driver",
-          "description": "Driver to bind",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        },
-        {
-          "name": "nameString",
-          "type": "string",
-          "description": "Resource name string",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        },
-        {
-          "name": "options",
-          "type": "Object",
-          "description": "Optional settings",
-          "default": "{}",
-          "optional": true,
-          "nullable": ""
-        }
-      ],
-      "examples": [
-        "const { fromDriver } = require('clay-resource')\nconst { SqliteDriver } = require('clay-driver-sqlite')\n{\n  let driver = new SqliteDriver('var/test.db')\n  let resource = fromDriver(driver)\n}"
-      ],
-      "returns": {
-        "type": "ClayResource",
-        "description": "Resource instance"
-      }
-    },
-    {
-      "name": "annotateMix",
-      "access": "",
-      "virtual": false,
-      "description": "Mixin for annotate feature",
-      "parameters": [
-        {
-          "name": "BaseClass",
-          "type": "function",
-          "description": "Class to mix",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        }
-      ],
-      "examples": [],
-      "returns": {
-        "type": "function",
-        "description": "Mixed class"
-      }
-    },
-    {
-      "name": "annotates",
-      "access": "",
-      "virtual": false,
-      "description": "Toggle annotate support",
-      "parameters": [
-        {
-          "name": "annotates",
-          "type": "boolean",
-          "description": "Should annotate or not",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        }
-      ],
-      "examples": [],
-      "returns": {
-        "type": "AnnotateMixed",
-        "description": "this"
-      }
-    },
-    {
-      "name": "cacheMix",
-      "access": "",
-      "virtual": false,
-      "description": "Mixin for cache",
-      "parameters": [
-        {
-          "name": "BaseClass",
-          "type": "function",
-          "description": "Class to mix",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        }
-      ],
-      "examples": [],
-      "returns": {
-        "type": "function",
-        "description": "Mixed class"
-      }
-    },
-    {
-      "name": "cloneMix",
-      "access": "",
-      "virtual": false,
-      "description": "Mixin for clone feature",
-      "parameters": [
-        {
-          "name": "BaseClass",
-          "type": "function",
-          "description": "Class to mix",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        }
-      ],
-      "examples": [],
-      "returns": {
-        "type": "function",
-        "description": "Mixed class"
-      }
-    },
-    {
-      "name": "collectionMix",
-      "access": "",
-      "virtual": false,
-      "description": "Mixin for collection",
-      "parameters": [
-        {
-          "name": "BaseClass",
-          "type": "function",
-          "description": "Class to mix",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        }
-      ],
-      "examples": [],
-      "returns": {
-        "type": "function",
-        "description": "Mixed class"
-      }
-    },
-    {
-      "name": "conditionMix",
-      "access": "",
-      "virtual": false,
-      "description": "Mixin for condition",
-      "parameters": [
-        {
-          "name": "BaseClass",
-          "type": "function",
-          "description": "Class to mix",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        }
-      ],
-      "examples": [],
-      "returns": {
-        "type": "function",
-        "description": "Mixed class"
-      }
-    },
-    {
-      "name": "decorateMix",
-      "access": "private",
-      "virtual": false,
-      "description": "Mix decorate support",
-      "parameters": [
-        {
-          "name": "BaseClass",
-          "type": "function",
-          "description": "Class to mix",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        }
-      ],
-      "examples": [],
-      "returns": {
-        "type": "function",
-        "description": "Mixed class"
-      }
-    },
-    {
-      "name": "entityMix",
-      "access": "",
-      "virtual": false,
-      "description": "Mixin for entity",
-      "parameters": [
-        {
-          "name": "BaseClass",
-          "type": "function",
-          "description": "Class to mix",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        }
-      ],
-      "examples": [],
-      "returns": {
-        "type": "function",
-        "description": "Mixed class"
-      }
-    },
-    {
-      "name": "inboundMix",
-      "access": "",
-      "virtual": false,
-      "description": "Mixin for inbound feature. Convert in-bind data like attributes to create/update",
-      "parameters": [
-        {
-          "name": "BaseClass",
-          "type": "function",
-          "description": "Class to mix",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        }
-      ],
-      "examples": [],
-      "returns": {
-        "type": "function",
-        "description": "Mixed class"
-      }
-    },
-    {
-      "name": "internalMix",
-      "access": "",
-      "virtual": false,
-      "description": "Mixin for internal feature",
-      "parameters": [
-        {
-          "name": "BaseClass",
-          "type": "function",
-          "description": "Class to mix",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        }
-      ],
-      "examples": [],
-      "returns": {
-        "type": "function",
-        "description": "Mixed class"
-      }
-    },
-    {
-      "name": "outboundMix",
-      "access": "",
-      "virtual": false,
-      "description": "Mixin for outbound feature. Convert out-bind data like entity, collection",
-      "parameters": [
-        {
-          "name": "BaseClass",
-          "type": "function",
-          "description": "Class to mix",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        }
-      ],
-      "examples": [],
-      "returns": {
-        "type": "function",
-        "description": "Mixed class"
-      }
-    },
-    {
-      "name": "policyMix",
-      "access": "",
-      "virtual": false,
-      "description": "Mixin for policy feature",
-      "parameters": [
-        {
-          "name": "BaseClass",
-          "type": "function",
-          "description": "Class to mix",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        }
-      ],
-      "examples": [],
-      "returns": {
-        "type": "function",
-        "description": "Mixed class"
-      }
-    },
-    {
-      "name": "prepareMix",
-      "access": "",
-      "virtual": false,
-      "description": "Mixin for prepare feature",
-      "parameters": [
-        {
-          "name": "BaseClass",
-          "type": "function",
-          "description": "Class to mix",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        }
-      ],
-      "examples": [],
-      "returns": {
-        "type": "function",
-        "description": "Mixed class"
-      }
-    },
-    {
-      "name": "refMix",
-      "access": "",
-      "virtual": false,
-      "description": "Mixin for ref feature",
-      "parameters": [
-        {
-          "name": "BaseClass",
-          "type": "function",
-          "description": "Class to mix",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        }
-      ],
-      "examples": [],
-      "returns": {
-        "type": "function",
-        "description": "Mixed class"
-      }
-    },
-    {
-      "name": "subMix",
-      "access": "",
-      "virtual": false,
-      "description": "Mixin for sub feature",
-      "parameters": [
-        {
-          "name": "BaseClass",
-          "type": "function",
-          "description": "Class to mix",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        }
-      ],
-      "examples": [],
-      "returns": {
-        "type": "function",
-        "description": "Mixed class"
-      }
-    },
-    {
-      "name": "throwMix",
-      "access": "",
-      "virtual": false,
-      "description": "Mixin for throw feature.",
-      "parameters": [
-        {
-          "name": "BaseClass",
-          "type": "function",
-          "description": "Class to mix",
-          "default": "",
-          "optional": "",
-          "nullable": ""
-        }
-      ],
-      "examples": [],
-      "returns": {
-        "type": "function",
-        "description": "Mixed class"
-      }
-    }
-  ]
+    ]
 }

--- a/lib/clay_resource.js
+++ b/lib/clay_resource.js
@@ -117,6 +117,7 @@ class ClayResource extends ClayResourceBase {
       name,
       domain,
       bounds,
+      _formatId: (id) => sureId(id, { prefix: nameString }),
       _resourceNameString: String(resourceName)
     })
 
@@ -145,13 +146,13 @@ class ClayResource extends ClayResourceBase {
       skipResolvingRefFor = null,
       strict = false
     } = options
-    return co(function * () {
+    return co(function* () {
       yield s.prepareIfNeeded()
       let actionContext = actionContextFor('one', {
         id,
         skipResolvingRefFor
       })
-      id = sureId(id)
+      id = s._formatId(id)
       let cached = s.gainCache(id)
       if (cached) {
         return s.outboundEntity(cached, actionContext)
@@ -191,7 +192,7 @@ class ClayResource extends ClayResourceBase {
    */
   list (condition = {}) {
     const s = this
-    return co(function * () {
+    return co(function* () {
       yield s.prepareIfNeeded()
       let actionContext = actionContextFor('list', { condition })
       let collection = yield s.bounds.list(
@@ -224,7 +225,7 @@ class ClayResource extends ClayResourceBase {
       allowReserved = false
     } = options
     const s = this
-    return co(function * () {
+    return co(function* () {
       yield s.prepareIfNeeded()
       let actionContext = actionContextFor('create', {})
       attributes = yield s.inboundAttributes(attributes, actionContext)
@@ -261,9 +262,9 @@ class ClayResource extends ClayResourceBase {
    */
   update (id, attributes = {}) {
     const s = this
-    return co(function * () {
+    return co(function* () {
       yield s.prepareIfNeeded()
-      id = sureId(id)
+      id = s._formatId(id)
       let actionContext = actionContextFor('update', { id })
       attributes = yield s.inboundAttributes(attributes, actionContext)
       let has = yield s.has(id)
@@ -292,9 +293,9 @@ class ClayResource extends ClayResourceBase {
    */
   destroy (id) {
     const s = this
-    return co(function * () {
+    return co(function* () {
       yield s.prepareIfNeeded()
-      id = sureId(id)
+      id = s._formatId(id)
       let destroyed = yield s.bounds.destroy(id)
       s.emit(ENTITY_DESTROY, { id, destroyed })
       yield tick()
@@ -314,7 +315,7 @@ class ClayResource extends ClayResourceBase {
    */
   drop () {
     const s = this
-    return co(function * () {
+    return co(function* () {
       let dropped = yield s.bounds.drop()
       s.emit(ENTITY_DROP, { dropped })
       yield tick()
@@ -336,7 +337,7 @@ class ClayResource extends ClayResourceBase {
    */
   oneBulk (ids) {
     const s = this
-    return co(function * () {
+    return co(function* () {
       yield s.prepareIfNeeded()
       let actionContext = actionContextFor('oneBulk', { ids })
       let oneHash = yield s.bounds.oneBulk(ids)
@@ -362,7 +363,7 @@ class ClayResource extends ClayResourceBase {
    */
   listBulk (conditionArray = []) {
     const s = this
-    return co(function * () {
+    return co(function* () {
       yield s.prepareIfNeeded()
       let actionContext = actionContextFor('listBulk', { conditionArray })
       let collectionArray = (yield s.bounds.listBulk(
@@ -392,7 +393,7 @@ class ClayResource extends ClayResourceBase {
    */
   createBulk (attributesArray = []) {
     const s = this
-    return co(function * () {
+    return co(function* () {
       yield s.prepareIfNeeded()
       let actionContext = actionContextFor('createBulk', {})
       attributesArray = yield s.inboundAttributesArray(attributesArray, actionContext)
@@ -423,7 +424,7 @@ class ClayResource extends ClayResourceBase {
    */
   updateBulk (attributesHash = {}) {
     const s = this
-    return co(function * () {
+    return co(function* () {
       yield s.prepareIfNeeded()
       let ids = Object.keys(attributesHash)
       let actionContext = actionContextFor('updateBulk', { ids })
@@ -458,7 +459,7 @@ class ClayResource extends ClayResourceBase {
    */
   destroyBulk (ids = []) {
     const s = this
-    return co(function * () {
+    return co(function* () {
       yield s.prepareIfNeeded()
       ids = ids.map(sureId)
       let destroyed = yield s.bounds.destroyBulk(ids)
@@ -490,7 +491,7 @@ class ClayResource extends ClayResourceBase {
    */
   cursor (options = {}) {
     const s = this
-    return co(function * () {
+    return co(function* () {
       yield s.prepareIfNeeded()
       let cursor = yield s.bounds.cursor(options)
       return cursor
@@ -518,7 +519,7 @@ class ClayResource extends ClayResourceBase {
       skip = 0
     } = options
     let actionContext = actionContextFor('first', {})
-    return co(function * () {
+    return co(function* () {
       yield s.prepareIfNeeded()
       let page = { size: 1, number: 1 + skip }
       let { entities } = yield s.list({ filter, page, sort })
@@ -545,7 +546,7 @@ class ClayResource extends ClayResourceBase {
     let {
       strict = false
     } = options
-    return co(function * () {
+    return co(function* () {
       yield s.prepareIfNeeded()
       let count = yield s.count(filter)
       if (count > 1) {
@@ -579,7 +580,7 @@ class ClayResource extends ClayResourceBase {
   seal (privateKey, options = {}) {
     const s = this
     let { by = null } = options
-    return co(function * () {
+    return co(function* () {
       yield s.prepareIfNeeded()
       let cursor = yield s.cursor({
         // TODO Filter with seal
@@ -609,9 +610,9 @@ class ClayResource extends ClayResourceBase {
    */
   has (id) {
     const s = this
-    return co(function * () {
+    return co(function* () {
       yield s.prepareIfNeeded()
-      id = sureId(id)
+      id = s._formatId(id)
       let one = yield s.one(id, { strict: false })
       return !!one
     })
@@ -631,7 +632,7 @@ class ClayResource extends ClayResourceBase {
    */
   exists (filter = {}) {
     const s = this
-    return co(function * () {
+    return co(function* () {
       yield s.prepareIfNeeded()
       let count = yield s.count(filter)
       return count > 0
@@ -652,7 +653,7 @@ class ClayResource extends ClayResourceBase {
    */
   count (filter = {}) {
     const s = this
-    return co(function * () {
+    return co(function* () {
       yield s.prepareIfNeeded()
       let { meta } = yield s.list({ page: { number: 1, size: 1 }, filter })
       return meta.total
@@ -673,7 +674,7 @@ class ClayResource extends ClayResourceBase {
    */
   of (attributes = {}) {
     const s = this
-    return co(function * () {
+    return co(function* () {
       yield s.prepareIfNeeded()
       let found = yield s.first(attributes)
       if (found) {
@@ -694,7 +695,7 @@ class ClayResource extends ClayResourceBase {
     const s = this
     let { sort = [] } = options
     let actionContext = actionContextFor('all', {})
-    return co(function * () {
+    return co(function* () {
       yield s.prepareIfNeeded()
       let { entities } = yield s.list({ filter, sort })
       return s.outboundEntityArray(entities, actionContext)

--- a/lib/helpers/sure_id.js
+++ b/lib/helpers/sure_id.js
@@ -11,8 +11,8 @@
 /** @lends sureId */
 function sureId (id, options = {}) {
   if (!id) {
-    const { prefix = 'Clay-Resource' } = options
-    throw new Error(`[${prefix}] id is required`)
+    const { prefix = 'Resource' } = options
+    throw new Error(`[Clay][${prefix}] id is required`)
   }
   return id.id || id
 }

--- a/lib/helpers/sure_id.js
+++ b/lib/helpers/sure_id.js
@@ -2,14 +2,17 @@
  * Make sure that given object is an id
  * @function sureId
  * @param {*} id
+ * @param {Object} [options={}] - Optional settings
+ * @param {string} [options.prefix] - Prefix for errors
  * @return {ClayId|String} id
  */
 'use strict'
 
 /** @lends sureId */
-function sureId (id) {
+function sureId (id, options = {}) {
   if (!id) {
-    throw new Error('[Clay-Resource] id is required')
+    const { prefix = 'Clay-Resource' } = options
+    throw new Error(`[${prefix}] id is required`)
   }
   return id.id || id
 }

--- a/lib/helpers/sure_id.js
+++ b/lib/helpers/sure_id.js
@@ -11,7 +11,7 @@
 /** @lends sureId */
 function sureId (id, options = {}) {
   if (!id) {
-    const { prefix = 'Resource' } = options
+    const {prefix = 'Resource'} = options
     throw new Error(`[Clay][${prefix}] id is required`)
   }
   return id.id || id

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-resource",
-  "version": "3.1.14",
+  "version": "3.1.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11,9 +11,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "6.0.81",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.81.tgz",
-      "integrity": "sha512-KdtXOH8l9O2wwOOX+swjbFx+YW/RJFfI14o6S50+Zy79FK1WFGkzFdDsiuNjrG5L6FaBSKpKzSpWgTvXurbbYg==",
+      "version": "6.0.84",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.84.tgz",
+      "integrity": "sha512-1SvEazClhUBRNroJM3oB3xf3u2r6xGmHDGbdigqNPHvNKLl8/BtATgO9eC04ZLuovpSh0B20BF1QJxdi+qmTlg==",
       "dev": true
     },
     "ababel": {
@@ -149,6 +149,16 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
+    },
+    "amkdirp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/amkdirp/-/amkdirp-1.0.0.tgz",
+      "integrity": "sha1-ArzaXnqf6PJgU87DzO5sxuMVLVs=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "mkdirp": "0.5.1"
+      }
     },
     "amocha": {
       "version": "2.0.0",
@@ -1126,19 +1136,6 @@
         "co": "4.6.0"
       }
     },
-    "clay-driver-benchmarks": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/clay-driver-benchmarks/-/clay-driver-benchmarks-2.0.1.tgz",
-      "integrity": "sha1-AXd1k/39JEO9LIHcs6THrBXEIKk=",
-      "dev": true,
-      "requires": {
-        "asleep": "1.0.3",
-        "clay-constants": "3.0.3",
-        "co": "4.6.0",
-        "colorprint": "4.1.0",
-        "debug": "2.6.8"
-      }
-    },
     "clay-driver-memory": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/clay-driver-memory/-/clay-driver-memory-4.0.5.tgz",
@@ -1153,43 +1150,52 @@
         "clay-list-filter": "2.1.4",
         "clay-list-pager": "2.0.2",
         "clay-list-sorter": "2.0.1",
-        "clay-resource-name": "4.0.1",
+        "clay-resource-name": "4.0.2",
         "co": "4.6.0"
       }
     },
     "clay-driver-sequelize": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/clay-driver-sequelize/-/clay-driver-sequelize-4.0.6.tgz",
-      "integrity": "sha1-J1uScpmt/rkZKmeBGFjcXtDELqE=",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/clay-driver-sequelize/-/clay-driver-sequelize-5.0.10.tgz",
+      "integrity": "sha1-2oexNZ0SpCJqZyONwpHyUU86D8A=",
       "dev": true,
       "requires": {
+        "asenv": "1.1.1",
         "asleep": "1.0.3",
+        "asobj": "1.5.0",
         "clay-collection": "3.0.1",
         "clay-constants": "3.0.3",
         "clay-driver-base": "3.0.1",
         "clay-entity": "2.0.4",
         "clay-id": "3.0.2",
         "clay-list-pager": "2.0.2",
-        "clay-resource-name": "4.0.1",
+        "clay-resource-name": "4.0.2",
         "clay-serial": "2.0.3",
-        "co": "4.6.0",
         "continuation-local-storage": "3.2.0",
         "objnest": "3.0.9",
-        "sequelize": "4.3.1",
-        "sg-queue": "1.1.4"
+        "retry-as-promised": "2.2.0",
+        "sequelize": "4.4.0",
+        "sg-queue": "1.1.4",
+        "stringcase": "4.0.0"
+      },
+      "dependencies": {
+        "stringcase": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/stringcase/-/stringcase-4.0.0.tgz",
+          "integrity": "sha512-ryXUPNsAKdg30OAW4XQW3tf03rmR9Cp/Umf0wZP3DhHG0GT12gv09b8tTJuEEqgp9c66fgUYUn4dww9nh85L2w==",
+          "dev": true
+        }
       }
     },
     "clay-driver-sqlite": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/clay-driver-sqlite/-/clay-driver-sqlite-4.0.2.tgz",
-      "integrity": "sha1-3MYIMA/N5evSRiFK1YDDcYmMLw4=",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/clay-driver-sqlite/-/clay-driver-sqlite-5.0.3.tgz",
+      "integrity": "sha1-cpwJd5nhxbFa9nmBraGmMJhyFYk=",
       "dev": true,
       "requires": {
         "asobj": "1.5.0",
         "clay-constants": "3.0.3",
-        "clay-driver-benchmarks": "2.0.1",
-        "clay-driver-sequelize": "4.0.6",
-        "co": "4.6.0",
+        "clay-driver-sequelize": "5.0.10",
         "mkdirp": "0.5.1"
       }
     },
@@ -1268,7 +1274,7 @@
       "requires": {
         "asobj": "1.5.0",
         "clay-collection": "3.0.1",
-        "clay-resource-name": "4.0.1",
+        "clay-resource-name": "4.0.2",
         "co": "4.6.0"
       }
     },
@@ -1278,14 +1284,14 @@
       "integrity": "sha1-qrXQRZ+hR2g53NlcLLOExQsET0Y=",
       "requires": {
         "clay-entity": "2.0.4",
-        "clay-resource-name": "4.0.1",
+        "clay-resource-name": "4.0.2",
         "co": "4.6.0"
       }
     },
     "clay-resource-name": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/clay-resource-name/-/clay-resource-name-4.0.1.tgz",
-      "integrity": "sha1-/KDmbZfk0+qkQj8cCOOiYu4RuvU=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/clay-resource-name/-/clay-resource-name-4.0.2.tgz",
+      "integrity": "sha1-5ciedmQtAfp5JZu90SiV8pST+0c=",
       "requires": {
         "clay-constants": "3.0.3",
         "co": "4.6.0"
@@ -1298,7 +1304,7 @@
       "requires": {
         "clay-entity": "2.0.4",
         "clay-id": "3.0.2",
-        "clay-resource-name": "4.0.1",
+        "clay-resource-name": "4.0.2",
         "co": "4.6.0"
       }
     },
@@ -3463,9 +3469,9 @@
       "dev": true
     },
     "sequelize": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-4.3.1.tgz",
-      "integrity": "sha1-zXNfGgJn5PodjSJ1bQL06WO4CNA=",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-4.4.0.tgz",
+      "integrity": "sha1-5WLToBA/bYBSewxa/AFO0k0MXIQ=",
       "dev": true,
       "requires": {
         "bluebird": "3.5.0",
@@ -4821,6 +4827,28 @@
         "terraformer": "1.0.8"
       }
     },
+    "the-script-jsdoc": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/the-script-jsdoc/-/the-script-jsdoc-1.0.8.tgz",
+      "integrity": "sha512-C3C8gCeysyta49DisyISlqYon2Ai1QDvqWX8eSxSPMrPvIyGAQCV2FSY5imreh+j1TggmuE8rMypQ5hLWdiJLw==",
+      "dev": true,
+      "requires": {
+        "aglob": "2.0.1",
+        "amkdirp": "1.0.0",
+        "argx": "3.0.2",
+        "co": "4.6.0",
+        "filedel": "3.0.0",
+        "stringcase": "4.0.0"
+      },
+      "dependencies": {
+        "stringcase": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/stringcase/-/stringcase-4.0.0.tgz",
+          "integrity": "sha512-ryXUPNsAKdg30OAW4XQW3tf03rmR9Cp/Umf0wZP3DhHG0GT12gv09b8tTJuEEqgp9c66fgUYUn4dww9nh85L2w==",
+          "dev": true
+        }
+      }
+    },
     "timers-ext": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz",
@@ -5006,7 +5034,7 @@
       "integrity": "sha1-L8FxtenLVcYlb+9L3h8hvkE77+4=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.81"
+        "@types/node": "6.0.84"
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "clay-resource-cache": "^1.0.4",
     "clay-resource-collection": "^1.0.1",
     "clay-resource-entity": "^1.0.4",
-    "clay-resource-name": "^4.0.1",
+    "clay-resource-name": "^4.0.2",
     "clay-resource-ref": "^2.0.2",
     "clay-schemas": "^4.0.5",
     "co": "^4.6.0"
@@ -48,7 +48,7 @@
     "ape-tmpl": "^5.0.20",
     "ape-updating": "^4.1.1",
     "clay-driver-memory": "^4.0.5",
-    "clay-driver-sqlite": "^4.0.2",
+    "clay-driver-sqlite": "^5.0.3",
     "claydb-assets": "^2.0.3",
     "coz": "^6.0.20",
     "filecopy": "^3.0.1",
@@ -58,6 +58,7 @@
     "sg-templates": "^1.4.4",
     "sqlite3": "^3.1.8",
     "sugos-travis": "^2.0.7",
+    "the-script-jsdoc": "^1.0.8",
     "writeout": "^2.2.0"
   },
   "engines": {

--- a/test/from_driver_test.js
+++ b/test/from_driver_test.js
@@ -19,15 +19,15 @@ const { DataTypes } = clayPolicy
 describe('from-driver', function () {
   this.timeout(30000)
 
-  before(() => co(function* () {
+  before(() => co(function * () {
 
   }))
 
-  after(() => co(function* () {
+  after(() => co(function * () {
 
   }))
 
-  it('From driver', () => co(function* () {
+  it('From driver', () => co(function * () {
     let driver = clayDriverMemory()
     let resource = fromDriver(driver, 'hogehoge', { annotates: true })
 
@@ -90,7 +90,7 @@ describe('from-driver', function () {
     }
   }))
 
-  it('From driver without annotate', () => co(function* () {
+  it('From driver without annotate', () => co(function * () {
     let driver = clayDriverMemory()
     let resource = fromDriver(driver, 'hogehoge').annotates(false)
 
@@ -151,7 +151,7 @@ describe('from-driver', function () {
     }
   }))
 
-  it('From driver bulk', () => co(function* () {
+  it('From driver bulk', () => co(function * () {
     let driver = clayDriverMemory()
     let resource = fromDriver(driver, 'hogehoge', { annotate: true })
 
@@ -177,7 +177,7 @@ describe('from-driver', function () {
     equal(count, 1)
   }))
 
-  it('From driver seal', () => co(function* () {
+  it('From driver seal', () => co(function * () {
     let driver = clayDriverMemory()
     let resource = fromDriver(driver, 'hogehoge').clone().annotates(true)
     let created = yield resource.create({ foo: 'bar' })
@@ -196,7 +196,7 @@ describe('from-driver', function () {
     ok(!decorate(one).verify(publicKey))
   }))
 
-  it('Resolve refs', () => co(function* () {
+  it('Resolve refs', () => co(function * () {
     let driver = clayDriverMemory()
     let Org = fromDriver(driver, 'Org')
     let User = fromDriver(driver, 'User').refs(Org)
@@ -223,7 +223,7 @@ describe('from-driver', function () {
     equal(team01.users[ 0 ].name, 'user01')
   }))
 
-  it('Policy check', () => co(function* () {
+  it('Policy check', () => co(function * () {
     const { STRING, DATE } = clayPolicy.DataTypes
     let driver = clayDriverMemory()
     let User = fromDriver(driver, 'User')
@@ -263,7 +263,7 @@ describe('from-driver', function () {
     equal(user02.username, 'hoge', 'Should be trimmed')
   }))
 
-  it('of', () => co(function* () {
+  it('of', () => co(function * () {
     let driver = clayDriverMemory()
     let Product = fromDriver(driver, 'Product')
     let product01 = yield Product.of({ code: '#1234' })
@@ -273,7 +273,7 @@ describe('from-driver', function () {
     yield Product.drop()
   }))
 
-  it('Unique', () => co(function* () {
+  it('Unique', () => co(function * () {
     let driver = clayDriverMemory()
     let Fruit = fromDriver(driver, 'Fruit')
     Fruit.policy({
@@ -293,7 +293,7 @@ describe('from-driver', function () {
     yield Fruit.drop()
   }))
 
-  it('Default', () => co(function* () {
+  it('Default', () => co(function * () {
     let driver = clayDriverMemory()
     let Box = fromDriver(driver, 'Box')
     Box.policy({
@@ -316,7 +316,7 @@ describe('from-driver', function () {
     equal(toyBox3.type, 'Steal')
   }))
 
-  it('Save/Fetch policy', () => co(function* () {
+  it('Save/Fetch policy', () => co(function * () {
     let driver = clayDriverMemory()
     let Fruit = fromDriver(driver, 'Fruit')
     let policy = clayPolicy({
@@ -331,7 +331,7 @@ describe('from-driver', function () {
     ok(fetched.hasRestrictionFor('name'))
   }))
 
-  it('Using cache', () => co(function* () {
+  it('Using cache', () => co(function * () {
     let driver = clayDriverMemory()
     let Fruit = fromDriver(driver, 'Fruit')
 
@@ -356,7 +356,7 @@ describe('from-driver', function () {
     equal(orange01AgainAgain, null)
   }))
 
-  it('Search by ref', () => co(function* () {
+  it('Search by ref', () => co(function * () {
     let drivers = [
       clayDriverMemory(),
       clayDriverSqlite(`${__dirname}/../tmp/search-by-ref.db`)
@@ -388,7 +388,7 @@ describe('from-driver', function () {
     }
   }))
 
-  it('Circular refs', () => co(function* () {
+  it('Circular refs', () => co(function * () {
     let driver = clayDriverMemory()
     let Toy = fromDriver(driver, 'Toy')
     let House = fromDriver(driver, 'House')
@@ -411,7 +411,7 @@ describe('from-driver', function () {
   }))
 
   // https://github.com/realglobe-Inc/claydb/issues/8
-  it('claydb/issues/8', () => co(function* () {
+  it('claydb/issues/8', () => co(function * () {
     let driver = clayDriverMemory()
     let Org = fromDriver(driver, 'Org')
     let User = fromDriver(driver, 'User')
@@ -423,7 +423,7 @@ describe('from-driver', function () {
     ok(user.org.$$entity)
   }))
 
-  it('Add invalid ref', () => co(function* () {
+  it('Add invalid ref', () => co(function * () {
     let driver = clayDriverMemory()
     let Org = fromDriver(driver, 'Org')
     let User = fromDriver(driver, 'User')
@@ -440,7 +440,7 @@ describe('from-driver', function () {
     ok(user01)
   }))
 
-  it('Convert id', () => co(function* () {
+  it('Convert id', () => co(function * () {
     let driver = clayDriverMemory()
     let User = fromDriver(driver, 'User')
     let user01 = yield User.create({ name: 'Rider01' })
@@ -454,7 +454,7 @@ describe('from-driver', function () {
     ok(!(yield User.has(user01)))
   }))
 
-  it('Using entity bind', () => co(function* () {
+  it('Using entity bind', () => co(function * () {
     let driver = clayDriverMemory()
     let User = fromDriver(driver, 'User')
     let user01 = yield User.create({ name: 'Rider01' })
@@ -485,7 +485,7 @@ describe('from-driver', function () {
     }
   }))
 
-  it('Use strict options', () => co(function* () {
+  it('Use strict options', () => co(function * () {
     let driver = clayDriverMemory()
     let User = fromDriver(driver, 'User')
     let user01 = yield User.create({ name: 'Rider01' })
@@ -502,7 +502,7 @@ describe('from-driver', function () {
     ok(caught)
   }))
 
-  it('Use resource collection', () => co(function* () {
+  it('Use resource collection', () => co(function * () {
     const driver = clayDriverMemory()
     const User = fromDriver(driver, 'User')
     for (let i = 0; i < 102; i++) {
@@ -525,7 +525,7 @@ describe('from-driver', function () {
     ])
   }))
 
-  it('Enhance entity', () => co(function* () {
+  it('Enhance entity', () => co(function * () {
     const driver = clayDriverMemory()
     const User = fromDriver(driver, 'User')
     User.enhanceResourceEntity((UserEntity) =>
@@ -541,7 +541,7 @@ describe('from-driver', function () {
     equal(user01.fullName, 'Taka Okunishi')
   }))
 
-  it('Enhance collection', () => co(function* () {
+  it('Enhance collection', () => co(function * () {
     const driver = clayDriverMemory()
     const User = fromDriver(driver, 'User')
     User.enhanceResourceCollection((UserCollection) =>
@@ -571,7 +571,7 @@ describe('from-driver', function () {
   }))
 
   // https://github.com/realglobe-Inc/clay-resource/issues/51
-  it('issues/51', () => co(function* () {
+  it('issues/51', () => co(function * () {
     const driver = clayDriverMemory()
     const User = fromDriver(driver, 'User')
     const UserAuth = fromDriver(driver, 'UserAuth')
@@ -598,7 +598,7 @@ describe('from-driver', function () {
     equal(live.createdBy.userKey, 'miyazaki')
   }))
 
-  it('Numeric id', () => co(function* () {
+  it('Numeric id', () => co(function * () {
     const driver = clayDriverMemory()
     const Ball = fromDriver(driver, 'Ball')
 

--- a/test/from_driver_test.js
+++ b/test/from_driver_test.js
@@ -7,14 +7,14 @@
 const fromDriver = require('../lib/from_driver.js')
 const clayDriverMemory = require('clay-driver-memory')
 const clayDriverSqlite = require('clay-driver-sqlite')
-const { decorate } = require('clay-entity')
-const { ok, equal, strictEqual, deepEqual } = require('assert')
+const {decorate} = require('clay-entity')
+const {ok, equal, strictEqual, deepEqual} = require('assert')
 const asleep = require('asleep')
 const clayPolicy = require('clay-policy')
-const { refTo } = require('clay-resource-ref')
-const { generate: generateKeys, verify } = require('clay-crypto')
+const {refTo} = require('clay-resource-ref')
+const {generate: generateKeys, verify} = require('clay-crypto')
 const co = require('co')
-const { DataTypes } = clayPolicy
+const {DataTypes} = clayPolicy
 
 describe('from-driver', function () {
   this.timeout(30000)
@@ -29,20 +29,20 @@ describe('from-driver', function () {
 
   it('From driver', () => co(function * () {
     let driver = clayDriverMemory()
-    let resource = fromDriver(driver, 'hogehoge', { annotates: true })
+    let resource = fromDriver(driver, 'hogehoge', {annotates: true})
 
-    ok(!(yield resource.exists({ foo: 'bar' })))
+    ok(!(yield resource.exists({foo: 'bar'})))
 
-    let created = yield resource.create({ foo: 'bar' })
+    let created = yield resource.create({foo: 'bar'})
     ok(created)
     ok(created.id)
     ok(created.$$at)
 
-    ok(yield resource.exists({ foo: 'bar' }))
+    ok(yield resource.exists({foo: 'bar'}))
 
     equal(yield resource.count(), 1)
 
-    let { id } = created
+    let {id} = created
 
     let one = yield resource.one(id)
     equal(one.foo, 'bar')
@@ -50,17 +50,17 @@ describe('from-driver', function () {
 
     yield asleep(10)
 
-    let updated = yield resource.update(id, { foo2: 'bar2' })
+    let updated = yield resource.update(id, {foo2: 'bar2'})
     ok(updated)
     equal(updated.foo, 'bar')
     equal(updated.foo2, 'bar2')
     ok(updated.$$at > created.$$at)
 
-    let first = yield resource.first({ foo2: 'bar2' })
+    let first = yield resource.first({foo2: 'bar2'})
     ok(first)
     ok(first.foo2, 'bar2')
 
-    let only = yield resource.only({ foo2: 'bar2' })
+    let only = yield resource.only({foo2: 'bar2'})
     ok(only)
     ok(only.foo2, 'bar2')
 
@@ -70,12 +70,12 @@ describe('from-driver', function () {
     {
       let hogeResource = resource.sub('hoge')
       ok(hogeResource)
-      yield hogeResource.create({ fooSub: 'barSub' })
+      yield hogeResource.create({fooSub: 'barSub'})
 
       strictEqual(resource.sub('hoge'), resource.sub('hoge'), 'Using cache')
 
       equal(hogeResource.name, 'hogehogehoge')
-      ok(hogeResource.refs()[ 'hogehoge' ])
+      ok(hogeResource.refs()['hogehoge'])
     }
 
     {
@@ -94,9 +94,9 @@ describe('from-driver', function () {
     let driver = clayDriverMemory()
     let resource = fromDriver(driver, 'hogehoge').annotates(false)
 
-    let created = yield resource.create({ foo: 'bar' })
+    let created = yield resource.create({foo: 'bar'})
 
-    let { id } = created
+    let {id} = created
 
     let one = yield resource.one(id)
     equal(one.foo, 'bar')
@@ -112,10 +112,10 @@ describe('from-driver', function () {
         caught = e
       }
       ok(caught)
-      equal(caught.message, '[hogehoge] id is required')
+      equal(caught.message, '[Clay][hogehoge] id is required')
     }
 
-    let updated = yield resource.update(id, { foo2: 'bar2' })
+    let updated = yield resource.update(id, {foo2: 'bar2'})
     ok(updated)
     equal(updated.foo, 'bar')
     equal(updated.foo2, 'bar2')
@@ -125,27 +125,27 @@ describe('from-driver', function () {
 
     // Bulk
     {
-      let [ created ] = yield resource.createBulk([ { foo: 'bar' } ])
+      let [created] = yield resource.createBulk([{foo: 'bar'}])
       ok(created)
       ok(created.id)
       ok(!created.$$at)
 
-      let { id } = created
-      let one = (yield resource.oneBulk([ id ]))[ id ]
+      let {id} = created
+      let one = (yield resource.oneBulk([id]))[id]
       equal(one.foo, 'bar')
       equal(String(one.id), String(created.id))
 
       yield asleep(10)
 
-      let updated = (yield resource.updateBulk({ [id]: { foo2: 'bar2' } }))[ id ]
+      let updated = (yield resource.updateBulk({[id]: {foo2: 'bar2'}}))[id]
       ok(updated)
       equal(updated.foo, 'bar')
       equal(updated.foo2, 'bar2')
       ok(!updated.$$at)
 
-      equal((yield resource.all())[ 0 ].foo, 'bar')
+      equal((yield resource.all())[0].foo, 'bar')
 
-      let count = yield resource.destroyBulk([ created.id ])
+      let count = yield resource.destroyBulk([created.id])
       equal(count, 1)
 
     }
@@ -153,38 +153,38 @@ describe('from-driver', function () {
 
   it('From driver bulk', () => co(function * () {
     let driver = clayDriverMemory()
-    let resource = fromDriver(driver, 'hogehoge', { annotate: true })
+    let resource = fromDriver(driver, 'hogehoge', {annotate: true})
 
-    let [ created ] = yield resource.createBulk([ { foo: 'bar' } ])
+    let [created] = yield resource.createBulk([{foo: 'bar'}])
     ok(created)
     ok(created.id)
     ok(created.$$at)
 
-    let { id } = created
-    let one = (yield resource.oneBulk([ id ]))[ id ]
+    let {id} = created
+    let one = (yield resource.oneBulk([id]))[id]
     equal(one.foo, 'bar')
     equal(String(one.id), String(created.id))
 
     yield asleep(10)
 
-    let updated = (yield resource.updateBulk({ [id]: { foo2: 'bar2' } }))[ id ]
+    let updated = (yield resource.updateBulk({[id]: {foo2: 'bar2'}}))[id]
     ok(updated)
     equal(updated.foo, 'bar')
     equal(updated.foo2, 'bar2')
     ok(updated.$$at > created.$$at)
 
-    let count = yield resource.destroyBulk([ created.id ])
+    let count = yield resource.destroyBulk([created.id])
     equal(count, 1)
   }))
 
   it('From driver seal', () => co(function * () {
     let driver = clayDriverMemory()
     let resource = fromDriver(driver, 'hogehoge').clone().annotates(true)
-    let created = yield resource.create({ foo: 'bar' })
-    let { id } = created
+    let created = yield resource.create({foo: 'bar'})
+    let {id} = created
 
-    let { privateKey, publicKey } = generateKeys()
-    yield resource.seal(privateKey, { by: 'foo!' })
+    let {privateKey, publicKey} = generateKeys()
+    yield resource.seal(privateKey, {by: 'foo!'})
 
     let one = yield resource.one(id)
     ok(one.$$seal)
@@ -200,10 +200,10 @@ describe('from-driver', function () {
     let driver = clayDriverMemory()
     let Org = fromDriver(driver, 'Org')
     let User = fromDriver(driver, 'User').refs(Org)
-    let org01 = yield Org.create({ name: 'org01' })
+    let org01 = yield Org.create({name: 'org01'})
     let user01 = yield User.create({
       name: 'user01',
-      org: { $ref: refTo(Org, org01.id) }
+      org: {$ref: refTo(Org, org01.id)}
     })
     equal(user01.org.name, 'org01')
     let user02 = yield User.create({
@@ -212,19 +212,19 @@ describe('from-driver', function () {
     })
     equal(user02.org.name, 'org01')
 
-    equal(driver._storages.User[ String(user02.id) ].org.$ref, `Org#${org01.id}`)
+    equal(driver._storages.User[String(user02.id)].org.$ref, `Org#${org01.id}`)
 
     let Team = fromDriver(driver, 'Team').refs(User)
     let team01 = yield Team.create({
       name: 'Team01',
-      users: [ { $ref: refTo(User, user01.id) } ]
+      users: [{$ref: refTo(User, user01.id)}]
     })
     ok(team01)
-    equal(team01.users[ 0 ].name, 'user01')
+    equal(team01.users[0].name, 'user01')
   }))
 
   it('Policy check', () => co(function * () {
-    const { STRING, DATE } = clayPolicy.DataTypes
+    const {STRING, DATE} = clayPolicy.DataTypes
     let driver = clayDriverMemory()
     let User = fromDriver(driver, 'User')
 
@@ -239,7 +239,7 @@ describe('from-driver', function () {
       },
       rank: {
         type: STRING,
-        oneOf: [ 'GOLD', 'SLIVER', 'BRONZE' ]
+        oneOf: ['GOLD', 'SLIVER', 'BRONZE']
       }
     })
 
@@ -256,19 +256,19 @@ describe('from-driver', function () {
     deepEqual(caught.detail.failures.rank, {
       reason: 'UNEXPECTED_VALUE_ERROR',
       actual: 'SUPER',
-      expects: { oneOf: [ 'GOLD', 'SLIVER', 'BRONZE' ] }
+      expects: {oneOf: ['GOLD', 'SLIVER', 'BRONZE']}
     })
 
-    let user02 = yield User.create({ username: '  hoge  ' })
+    let user02 = yield User.create({username: '  hoge  '})
     equal(user02.username, 'hoge', 'Should be trimmed')
   }))
 
   it('of', () => co(function * () {
     let driver = clayDriverMemory()
     let Product = fromDriver(driver, 'Product')
-    let product01 = yield Product.of({ code: '#1234' })
+    let product01 = yield Product.of({code: '#1234'})
     equal(product01.code, '#1234')
-    let product02 = yield Product.of({ code: '#1234' })
+    let product02 = yield Product.of({code: '#1234'})
     equal(String(product01).id, String(product02).id)
     yield Product.drop()
   }))
@@ -282,10 +282,10 @@ describe('from-driver', function () {
         unique: true
       }
     })
-    yield Fruit.create({ name: 'banana' })
+    yield Fruit.create({name: 'banana'})
     let caught
     try {
-      yield Fruit.create({ name: 'banana' })
+      yield Fruit.create({name: 'banana'})
     } catch (thrown) {
       caught = thrown
     }
@@ -302,7 +302,7 @@ describe('from-driver', function () {
         default: 'Wood'
       }
     })
-    let toyBox = yield Box.create({ name: 'toy' })
+    let toyBox = yield Box.create({name: 'toy'})
     equal(toyBox.type, 'Wood')
     Box.policy({
       type: {
@@ -310,9 +310,9 @@ describe('from-driver', function () {
         default: 'Steal'
       }
     })
-    let toyBox2 = yield Box.update(toyBox.id, { name: 'toy2' })
+    let toyBox2 = yield Box.update(toyBox.id, {name: 'toy2'})
     equal(toyBox2.type, 'Wood')
-    let toyBox3 = yield Box.create({ name: 'toy3' })
+    let toyBox3 = yield Box.create({name: 'toy3'})
     equal(toyBox3.type, 'Steal')
   }))
 
@@ -335,8 +335,8 @@ describe('from-driver', function () {
     let driver = clayDriverMemory()
     let Fruit = fromDriver(driver, 'Fruit')
 
-    let orange01 = yield Fruit.create({ name: 'orange' })
-    let banana01 = yield Fruit.create({ name: 'banana' })
+    let orange01 = yield Fruit.create({name: 'orange'})
+    let banana01 = yield Fruit.create({name: 'banana'})
 
     yield Fruit.one(orange01.id)
     yield Fruit.one(orange01.id)
@@ -344,7 +344,7 @@ describe('from-driver', function () {
     yield Fruit.one(banana01.id)
     equal(Fruit._resourceCache.size, 2)
 
-    yield Fruit.update(orange01.id, { vr: 2 })
+    yield Fruit.update(orange01.id, {vr: 2})
     equal(Fruit._resourceCache.size, 1)
     let orange01Again = yield Fruit.one(orange01.id)
     equal(orange01Again.vr, 2)
@@ -367,21 +367,21 @@ describe('from-driver', function () {
       Org.refs(User)
       User.refs(Org)
 
-      let org01 = yield Org.create({ name: 'org01' })
-      let org02 = yield Org.create({ name: 'org02' })
-      yield User.create({ name: 'user01', org: org01 })
-      yield User.create({ name: 'user02', org: org02 })
+      let org01 = yield Org.create({name: 'org01'})
+      let org02 = yield Org.create({name: 'org02'})
+      yield User.create({name: 'user01', org: org01})
+      yield User.create({name: 'user02', org: org02})
 
-      let { meta, entities, demand } = yield User.list({ filter: { org: org01 } })
+      let {meta, entities, demand} = yield User.list({filter: {org: org01}})
       equal(meta.length, 1)
-      let [ user ] = entities
+      let [user] = entities
       equal(user.name, 'user01')
       equal(demand.filter.org.$ref, `Org#${org01.id}`)
 
       {
-        let [ { meta, entities, demand } ] = yield User.listBulk([ { filter: { org: org01 } } ])
+        let [{meta, entities, demand}] = yield User.listBulk([{filter: {org: org01}}])
         equal(meta.length, 1)
-        let [ user ] = entities
+        let [user] = entities
         equal(user.name, 'user01')
         equal(demand.filter.org.$ref, `Org#${org01.id}`)
       }
@@ -396,18 +396,18 @@ describe('from-driver', function () {
     Toy.refs(House)
     House.refs(Toy)
 
-    let house01 = yield House.create({ name: 'house01' })
+    let house01 = yield House.create({name: 'house01'})
 
-    let toy01 = yield Toy.create({ name: 'toy01', house: house01 })
-    let toy02 = yield Toy.create({ name: 'toy02', house: house01 })
+    let toy01 = yield Toy.create({name: 'toy01', house: house01})
+    let toy02 = yield Toy.create({name: 'toy02', house: house01})
 
-    yield House.update(house01.id, { toys: [ toy01, toy02 ] })
+    yield House.update(house01.id, {toys: [toy01, toy02]})
 
     let house01Again = yield House.one(house01.id)
-    equal(house01Again.toys[ 0 ].house.$ref, `House#${house01.id}`)
+    equal(house01Again.toys[0].house.$ref, `House#${house01.id}`)
 
     let toy01Again = yield Toy.one(toy01.id)
-    equal(toy01Again.house.toys[ 0 ].$ref, `Toy#${toy01.id}`)
+    equal(toy01Again.house.toys[0].$ref, `Toy#${toy01.id}`)
   }))
 
   // https://github.com/realglobe-Inc/claydb/issues/8
@@ -417,9 +417,9 @@ describe('from-driver', function () {
     let User = fromDriver(driver, 'User')
     Org.refs(User)
     User.refs(Org)
-    let realglobe = yield Org.create({ name: 'realglobe' })
+    let realglobe = yield Org.create({name: 'realglobe'})
     let realglobeObj = Object(realglobe)
-    let user = yield User.create({ name: 'fuji', org: realglobeObj })
+    let user = yield User.create({name: 'fuji', org: realglobeObj})
     ok(user.org.$$entity)
   }))
 
@@ -429,7 +429,7 @@ describe('from-driver', function () {
     let User = fromDriver(driver, 'User')
     Org.refs(User)
     User.refs(Org)
-    let org01 = yield Org.create({ name: 'FantasticPark' })
+    let org01 = yield Org.create({name: 'FantasticPark'})
     let user01 = yield User.create({
       name: 'Rider01',
       org: {
@@ -443,9 +443,9 @@ describe('from-driver', function () {
   it('Convert id', () => co(function * () {
     let driver = clayDriverMemory()
     let User = fromDriver(driver, 'User')
-    let user01 = yield User.create({ name: 'Rider01' })
+    let user01 = yield User.create({name: 'Rider01'})
 
-    yield User.update(user01, { name: 'Updated Rider01' })
+    yield User.update(user01, {name: 'Updated Rider01'})
 
     equal((yield User.one(user01)).name, 'Updated Rider01')
 
@@ -457,15 +457,15 @@ describe('from-driver', function () {
   it('Using entity bind', () => co(function * () {
     let driver = clayDriverMemory()
     let User = fromDriver(driver, 'User')
-    let user01 = yield User.create({ name: 'Rider01' })
+    let user01 = yield User.create({name: 'Rider01'})
     ok(user01.update)
     ok(user01.destroy)
     ok(Object.assign({}, user01).name)
     ok(!Object.assign({}, user01).update)
     ok(!Object.assign({}, user01).destroy)
 
-    yield user01.update({ version: 2 })
-    yield User.update(user01, { foo: 'bar' })
+    yield user01.update({version: 2})
+    yield User.update(user01, {foo: 'bar'})
     yield user01.sync()
     equal(user01.foo, 'bar')
     equal(user01.version, 2)
@@ -477,7 +477,7 @@ describe('from-driver', function () {
     {
       let caught
       try {
-        yield user01.update({ foo: 'bar' })
+        yield user01.update({foo: 'bar'})
       } catch (e) {
         caught = e
       }
@@ -488,14 +488,14 @@ describe('from-driver', function () {
   it('Use strict options', () => co(function * () {
     let driver = clayDriverMemory()
     let User = fromDriver(driver, 'User')
-    let user01 = yield User.create({ name: 'Rider01' })
-    yield User.one(user01.id, { strict: false })
-    yield User.one(user01.id, { strict: true })
+    let user01 = yield User.create({name: 'Rider01'})
+    yield User.one(user01.id, {strict: false})
+    yield User.one(user01.id, {strict: true})
 
-    yield User.one('__invalid_id__', { strict: false })
+    yield User.one('__invalid_id__', {strict: false})
     let caught
     try {
-      yield User.one('__invalid_id__', { strict: true })
+      yield User.one('__invalid_id__', {strict: true})
     } catch (e) {
       caught = e
     }
@@ -511,7 +511,7 @@ describe('from-driver', function () {
         group: i % 2 === 0 ? 'yellow' : 'green'
       })
     }
-    let users = yield User.list({ filter: { group: 'green' }, page: { number: 1, size: 25 } })
+    let users = yield User.list({filter: {group: 'green'}, page: {number: 1, size: 25}})
     let counts = []
     while (users.hasNext) {
       counts.push(users.meta)
@@ -519,9 +519,9 @@ describe('from-driver', function () {
     }
     counts.push(users.meta)
     deepEqual(counts, [
-      { offset: 0, limit: 25, length: 25, total: 51 },
-      { offset: 25, limit: 25, length: 25, total: 51 },
-      { offset: 50, limit: 25, length: 1, total: 51 }
+      {offset: 0, limit: 25, length: 25, total: 51},
+      {offset: 25, limit: 25, length: 25, total: 51},
+      {offset: 50, limit: 25, length: 1, total: 51}
     ])
   }))
 
@@ -531,13 +531,13 @@ describe('from-driver', function () {
     User.enhanceResourceEntity((UserEntity) =>
       class EnhancedUserEntity extends UserEntity {
         get fullName () {
-          let { familyName, firstName } = this
-          return [ firstName, familyName ].filter(Boolean).join(' ')
+          let {familyName, firstName} = this
+          return [firstName, familyName].filter(Boolean).join(' ')
         }
       }
     )
 
-    let user01 = yield User.create({ firstName: 'Taka', familyName: 'Okunishi' })
+    let user01 = yield User.create({firstName: 'Taka', familyName: 'Okunishi'})
     equal(user01.fullName, 'Taka Okunishi')
   }))
 
@@ -547,7 +547,7 @@ describe('from-driver', function () {
     User.enhanceResourceCollection((UserCollection) =>
       class EnhancedUserCollection extends UserCollection {
         nextOne () {
-          let { demand, page } = this
+          let {demand, page} = this
           return User.first(demand.filter, {
             sort: demand.sort,
             skip: page.size * page.number
@@ -556,16 +556,16 @@ describe('from-driver', function () {
       }
     )
 
-    yield User.create({ name: 'user01' })
-    yield User.create({ name: 'user02' })
-    yield User.create({ name: 'user03' })
+    yield User.create({name: 'user01'})
+    yield User.create({name: 'user02'})
+    yield User.create({name: 'user03'})
 
     let users = yield User.list({
       page: {
         size: 2,
         number: 1
       },
-      sort: [ '-name' ]
+      sort: ['-name']
     })
     equal((yield users.nextOne()).name, 'user01')
   }))
@@ -602,7 +602,7 @@ describe('from-driver', function () {
     const driver = clayDriverMemory()
     const Ball = fromDriver(driver, 'Ball')
 
-    let created = yield Ball.create({ id: 1 }, { allowReserved: true })
+    let created = yield Ball.create({id: 1}, {allowReserved: true})
     strictEqual(String(created.id), '1')
   }))
 })

--- a/test/from_driver_test.js
+++ b/test/from_driver_test.js
@@ -19,15 +19,15 @@ const { DataTypes } = clayPolicy
 describe('from-driver', function () {
   this.timeout(30000)
 
-  before(() => co(function * () {
+  before(() => co(function* () {
 
   }))
 
-  after(() => co(function * () {
+  after(() => co(function* () {
 
   }))
 
-  it('From driver', () => co(function * () {
+  it('From driver', () => co(function* () {
     let driver = clayDriverMemory()
     let resource = fromDriver(driver, 'hogehoge', { annotates: true })
 
@@ -90,7 +90,7 @@ describe('from-driver', function () {
     }
   }))
 
-  it('From driver without annotate', () => co(function * () {
+  it('From driver without annotate', () => co(function* () {
     let driver = clayDriverMemory()
     let resource = fromDriver(driver, 'hogehoge').annotates(false)
 
@@ -102,6 +102,18 @@ describe('from-driver', function () {
     equal(one.foo, 'bar')
     equal(String(one.id), String(id))
     ok(!one.$$at)
+
+    // One without ID
+    {
+      let caught
+      try {
+        yield resource.one()
+      } catch (e) {
+        caught = e
+      }
+      ok(caught)
+      equal(caught.message, '[hogehoge] id is required')
+    }
 
     let updated = yield resource.update(id, { foo2: 'bar2' })
     ok(updated)
@@ -139,7 +151,7 @@ describe('from-driver', function () {
     }
   }))
 
-  it('From driver bulk', () => co(function * () {
+  it('From driver bulk', () => co(function* () {
     let driver = clayDriverMemory()
     let resource = fromDriver(driver, 'hogehoge', { annotate: true })
 
@@ -165,7 +177,7 @@ describe('from-driver', function () {
     equal(count, 1)
   }))
 
-  it('From driver seal', () => co(function * () {
+  it('From driver seal', () => co(function* () {
     let driver = clayDriverMemory()
     let resource = fromDriver(driver, 'hogehoge').clone().annotates(true)
     let created = yield resource.create({ foo: 'bar' })
@@ -184,7 +196,7 @@ describe('from-driver', function () {
     ok(!decorate(one).verify(publicKey))
   }))
 
-  it('Resolve refs', () => co(function * () {
+  it('Resolve refs', () => co(function* () {
     let driver = clayDriverMemory()
     let Org = fromDriver(driver, 'Org')
     let User = fromDriver(driver, 'User').refs(Org)
@@ -211,7 +223,7 @@ describe('from-driver', function () {
     equal(team01.users[ 0 ].name, 'user01')
   }))
 
-  it('Policy check', () => co(function * () {
+  it('Policy check', () => co(function* () {
     const { STRING, DATE } = clayPolicy.DataTypes
     let driver = clayDriverMemory()
     let User = fromDriver(driver, 'User')
@@ -251,7 +263,7 @@ describe('from-driver', function () {
     equal(user02.username, 'hoge', 'Should be trimmed')
   }))
 
-  it('of', () => co(function * () {
+  it('of', () => co(function* () {
     let driver = clayDriverMemory()
     let Product = fromDriver(driver, 'Product')
     let product01 = yield Product.of({ code: '#1234' })
@@ -261,7 +273,7 @@ describe('from-driver', function () {
     yield Product.drop()
   }))
 
-  it('Unique', () => co(function * () {
+  it('Unique', () => co(function* () {
     let driver = clayDriverMemory()
     let Fruit = fromDriver(driver, 'Fruit')
     Fruit.policy({
@@ -281,7 +293,7 @@ describe('from-driver', function () {
     yield Fruit.drop()
   }))
 
-  it('Default', () => co(function * () {
+  it('Default', () => co(function* () {
     let driver = clayDriverMemory()
     let Box = fromDriver(driver, 'Box')
     Box.policy({
@@ -304,7 +316,7 @@ describe('from-driver', function () {
     equal(toyBox3.type, 'Steal')
   }))
 
-  it('Save/Fetch policy', () => co(function * () {
+  it('Save/Fetch policy', () => co(function* () {
     let driver = clayDriverMemory()
     let Fruit = fromDriver(driver, 'Fruit')
     let policy = clayPolicy({
@@ -319,7 +331,7 @@ describe('from-driver', function () {
     ok(fetched.hasRestrictionFor('name'))
   }))
 
-  it('Using cache', () => co(function * () {
+  it('Using cache', () => co(function* () {
     let driver = clayDriverMemory()
     let Fruit = fromDriver(driver, 'Fruit')
 
@@ -344,7 +356,7 @@ describe('from-driver', function () {
     equal(orange01AgainAgain, null)
   }))
 
-  it('Search by ref', () => co(function * () {
+  it('Search by ref', () => co(function* () {
     let drivers = [
       clayDriverMemory(),
       clayDriverSqlite(`${__dirname}/../tmp/search-by-ref.db`)
@@ -376,7 +388,7 @@ describe('from-driver', function () {
     }
   }))
 
-  it('Circular refs', () => co(function * () {
+  it('Circular refs', () => co(function* () {
     let driver = clayDriverMemory()
     let Toy = fromDriver(driver, 'Toy')
     let House = fromDriver(driver, 'House')
@@ -399,7 +411,7 @@ describe('from-driver', function () {
   }))
 
   // https://github.com/realglobe-Inc/claydb/issues/8
-  it('claydb/issues/8', () => co(function * () {
+  it('claydb/issues/8', () => co(function* () {
     let driver = clayDriverMemory()
     let Org = fromDriver(driver, 'Org')
     let User = fromDriver(driver, 'User')
@@ -411,7 +423,7 @@ describe('from-driver', function () {
     ok(user.org.$$entity)
   }))
 
-  it('Add invalid ref', () => co(function * () {
+  it('Add invalid ref', () => co(function* () {
     let driver = clayDriverMemory()
     let Org = fromDriver(driver, 'Org')
     let User = fromDriver(driver, 'User')
@@ -428,7 +440,7 @@ describe('from-driver', function () {
     ok(user01)
   }))
 
-  it('Convert id', () => co(function * () {
+  it('Convert id', () => co(function* () {
     let driver = clayDriverMemory()
     let User = fromDriver(driver, 'User')
     let user01 = yield User.create({ name: 'Rider01' })
@@ -442,7 +454,7 @@ describe('from-driver', function () {
     ok(!(yield User.has(user01)))
   }))
 
-  it('Using entity bind', () => co(function * () {
+  it('Using entity bind', () => co(function* () {
     let driver = clayDriverMemory()
     let User = fromDriver(driver, 'User')
     let user01 = yield User.create({ name: 'Rider01' })
@@ -473,7 +485,7 @@ describe('from-driver', function () {
     }
   }))
 
-  it('Use strict options', () => co(function * () {
+  it('Use strict options', () => co(function* () {
     let driver = clayDriverMemory()
     let User = fromDriver(driver, 'User')
     let user01 = yield User.create({ name: 'Rider01' })
@@ -490,7 +502,7 @@ describe('from-driver', function () {
     ok(caught)
   }))
 
-  it('Use resource collection', () => co(function * () {
+  it('Use resource collection', () => co(function* () {
     const driver = clayDriverMemory()
     const User = fromDriver(driver, 'User')
     for (let i = 0; i < 102; i++) {
@@ -513,7 +525,7 @@ describe('from-driver', function () {
     ])
   }))
 
-  it('Enhance entity', () => co(function * () {
+  it('Enhance entity', () => co(function* () {
     const driver = clayDriverMemory()
     const User = fromDriver(driver, 'User')
     User.enhanceResourceEntity((UserEntity) =>
@@ -529,7 +541,7 @@ describe('from-driver', function () {
     equal(user01.fullName, 'Taka Okunishi')
   }))
 
-  it('Enhance collection', () => co(function * () {
+  it('Enhance collection', () => co(function* () {
     const driver = clayDriverMemory()
     const User = fromDriver(driver, 'User')
     User.enhanceResourceCollection((UserCollection) =>
@@ -559,7 +571,7 @@ describe('from-driver', function () {
   }))
 
   // https://github.com/realglobe-Inc/clay-resource/issues/51
-  it('issues/51', () => co(function * () {
+  it('issues/51', () => co(function* () {
     const driver = clayDriverMemory()
     const User = fromDriver(driver, 'User')
     const UserAuth = fromDriver(driver, 'UserAuth')
@@ -586,7 +598,7 @@ describe('from-driver', function () {
     equal(live.createdBy.userKey, 'miyazaki')
   }))
 
-  it('Numeric id', () => co(function * () {
+  it('Numeric id', () => co(function* () {
     const driver = clayDriverMemory()
     const Ball = fromDriver(driver, 'Ball')
 


### PR DESCRIPTION
`.one(id)`とかに間違ってundefinedを渡した時のエラーが`id is required`だけで非常に困ったので、メッセージにリソース名をプレフィックスとして付与するように変えた。