### PR TITLE
Fix outboundEntityHash()

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ void async function () {
 API Guide
 -----
 
-+ [clay-resource@5.5.30](./doc/api/api.md)
++ [clay-resource@5.5.31](./doc/api/api.md)
   + [create(args)](./doc/api/api.md#clay-resource-function-create)
   + [fromDriver(driver, nameString, options)](./doc/api/api.md#clay-resource-function-from-driver)
   + [ClayResource](./doc/api/api.md#clay-resource-class)

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -1,4 +1,4 @@
-# clay-resource@5.5.30
+# clay-resource@5.5.31
 
 Resource accessor for ClayDB
 

--- a/doc/toc/.toc.md.bud
+++ b/doc/toc/.toc.md.bud
@@ -19,7 +19,6 @@ module.exports = {
   },
   tmpl (data){
     let { src } = data
-    console.log(src)
     return toc(src, {
       filter (line) {
         let rejectPatterns = [ /Table of Contents/ ]

--- a/lib/mixins/outbound_mix.js
+++ b/lib/mixins/outbound_mix.js
@@ -126,12 +126,11 @@ function outboundMix (BaseClass) {
       entityHash = Object.assign({}, entityHash)
       const ids = Object.keys(entityHash)
       const entities = await this.applyOutbound(
-        ids.map((id) => entityHash[id]).map((v) => v === null ? v : clayEntity(v)),
+        ids.map((id) => entityHash[id]).map((v) => v === null ? v : clayEntity(v)).filter(Boolean),
         actionContext
       )
-      for (let i = 0; i < ids.length; i++) {
-        entityHash[ids[i]] = entities[i]
-      }
+      const outboundedHash = entities.reduce((hash, entity) => Object.assign(hash, { [entity.id]: entity }), {})
+      Object.assign(entityHash, outboundedHash)
       return entityHash
     }
 

--- a/test/outbound_mix_test.js
+++ b/test/outbound_mix_test.js
@@ -5,6 +5,7 @@
 'use strict'
 
 const outboundMix = require('../lib/mixins/outbound_mix.js')
+const collectionMix = require('../lib/mixins/collection_mix')
 const assert = require('assert')
 
 
@@ -20,6 +21,30 @@ describe('outbound-mix', function () {
   })
 
   it('Outbound mix', async () => {
+    const OutboundMix = outboundMix(collectionMix(class BaseClass {}))
+    const outbound = new OutboundMix()
+    assert.ok(outbound)
+  })
+
+  it('Outbound mix. outboundEntityHash()', async () => {
+    const OutboundMix = outboundMix(collectionMix(class BaseClass {}))
+    const outbound = new OutboundMix()
+
+    outbound.addOutbound('outbound1', (resource, entities) => {
+      for (const entity of entities) {
+        entity.foo = 'foo'
+      }
+      return Promise.resolve(entities)
+    })
+
+    const entities = await outbound.outboundEntityHash({
+      '1': { id: '1' },
+      '2': null,
+    })
+    assert.deepStrictEqual(entities, {
+      '1': { id: '1', foo: 'foo' },
+      '2': null,
+    })
 
   })
 })

--- a/test/outbound_mix_test.js
+++ b/test/outbound_mix_test.js
@@ -7,7 +7,7 @@
 const outboundMix = require('../lib/mixins/outbound_mix.js')
 const collectionMix = require('../lib/mixins/collection_mix')
 const assert = require('assert')
-
+const clayEntity = require('clay-entity')
 
 describe('outbound-mix', function () {
   this.timeout(3000)
@@ -42,7 +42,7 @@ describe('outbound-mix', function () {
       '2': null,
     })
     assert.deepStrictEqual(entities, {
-      '1': { id: '1', foo: 'foo' },
+      '1': clayEntity({ id: '1', foo: 'foo' }),
       '2': null,
     })
 


### PR DESCRIPTION
これをすると null を outbound 関数に渡してエラーになるので修正した。

```js
outbound.outboundEntityHash({
  '1': { id: '1' },
  '2': null,
})
```